### PR TITLE
Explicitly create /nix et /nix/store in the tar archive

### DIFF
--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -24,9 +24,9 @@ func TestPerms(t *testing.T) {
 	}
 	expected := []types.Layer{
 		types.Layer{
-			Digest: "sha256:1d93274b1a59eed0a471f601a7f87ae58e2860566ed20313043b1efd983e8baa",
-			DiffIDs: "sha256:1d93274b1a59eed0a471f601a7f87ae58e2860566ed20313043b1efd983e8baa",
-			Size: 1536,
+			Digest: "sha256:7031b24697abf372b252fffb1432f685b364b742212df74787e2a2a8c8d4f66f",
+			DiffIDs: "sha256:7031b24697abf372b252fffb1432f685b364b742212df74787e2a2a8c8d4f66f",
+			Size: 3072,
 			Paths: types.Paths{
 				types.Path{
 					Path: "../data/layer1/file1",
@@ -58,9 +58,9 @@ func TestNewLayers(t *testing.T) {
 	}
 	expected := []types.Layer{
 		types.Layer{
-			Digest: "sha256:38856f8cd2e336497b6257e891ad860ea77e24193a726125445823618aa16cce",
-			DiffIDs: "sha256:38856f8cd2e336497b6257e891ad860ea77e24193a726125445823618aa16cce",
-			Size: 1536,
+			Digest: "sha256:a97d8eab8c8b698b1c5aa10625b30b3b47baf102d1c429d567023a05ebe53480",
+			DiffIDs: "sha256:a97d8eab8c8b698b1c5aa10625b30b3b47baf102d1c429d567023a05ebe53480",
+			Size: 3072,
 			Paths: types.Paths{
 				types.Path{
 					Path: "../data/layer1/file1",
@@ -80,16 +80,16 @@ func TestNewLayers(t *testing.T) {
 	}
 	expected = []types.Layer{
 		types.Layer{
-			Digest: "sha256:38856f8cd2e336497b6257e891ad860ea77e24193a726125445823618aa16cce",
-			DiffIDs: "sha256:38856f8cd2e336497b6257e891ad860ea77e24193a726125445823618aa16cce",
-			Size: 1536,
+			Digest: "sha256:a97d8eab8c8b698b1c5aa10625b30b3b47baf102d1c429d567023a05ebe53480",
+			DiffIDs: "sha256:a97d8eab8c8b698b1c5aa10625b30b3b47baf102d1c429d567023a05ebe53480",
+			Size: 3072,
 			Paths: types.Paths{
 				types.Path{
 					Path: "../data/layer1/file1",
 				},
 			},
 			MediaType: "application/vnd.oci.image.layer.v1.tar",
-			LayerPath: tmpDir + "/38856f8cd2e336497b6257e891ad860ea77e24193a726125445823618aa16cce.tar",
+			LayerPath: tmpDir + "/a97d8eab8c8b698b1c5aa10625b30b3b47baf102d1c429d567023a05ebe53480.tar",
 		},
 	}
 	if !reflect.DeepEqual(layer, expected) {

--- a/nix/tar_test.go
+++ b/nix/tar_test.go
@@ -13,11 +13,11 @@ func TestTar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	expectedDigest := "sha256:a0a389b8df6fec3293a0b26714f77d6aa252d2304de516daa683b4a55053dc5a"
+	expectedDigest := "sha256:efccbbe35209d59cfeebd8e73785258d3679fa258f72a7dfbc2eec65695fd5c8"
 	if digest.String() != expectedDigest {
 		t.Fatalf("Digest is %s while it should be %s", digest.String(), expectedDigest)
 	}
-	expectedSize := int64(2560)
+	expectedSize := int64(3584)
 	if size != expectedSize {
 		t.Fatalf("Size is %d while it should be %d", size, expectedSize)
 	}

--- a/nix/utils.go
+++ b/nix/utils.go
@@ -1,0 +1,66 @@
+package nix
+
+import (
+	"path/filepath"
+	"strings"
+	"sort"
+)
+
+type Node struct {
+	inTar bool
+	children map[string]*Node
+}
+
+// addPathInGraph adds a file and all missing file parents file
+// in the graph.
+// It also marks nodes that are in the tar.
+func addPathInGraph(root *Node, path string) {
+	var current *Node
+	var exist bool
+	components := strings.Split(filepath.Clean(path), "/")
+	if components[0] == "" {
+		components[0] = "/"
+	}
+	node := root
+	for _, component := range components {
+		current, exist = node.children[component]
+		if !exist {
+			current = &Node{
+				children: make(map[string]*Node),
+			}
+			node.children[component] = current
+		}
+		node = current
+	}
+	// This node exists in the tar
+	current.inTar = true
+}
+
+func collectPathsNotInTar(root *Node, base string) []string {
+	collected := []string{}
+	for name, child := range root.children {
+		path := filepath.Join(base, name)
+		if !child.inTar {
+			collected = append(collected, path)
+		}
+		collected = append(collected, collectPathsNotInTar(child, path)...)
+	}
+	return collected
+}
+
+// pathsNotInTar returns all paths that have not been explicitly
+// created. If the paths list only contains "/nix/store/hash", this
+// function returns ["/nix", "/nix/store"].  Note we don't want to
+// just create "/nix" and "/nix/store" directories because we want to be
+// "nix" specific (think of guix for instance).
+func pathsNotInTar(paths []string) ([]string) {
+	root := Node{
+		children: make(map[string]*Node),
+	}
+	for _, path := range(paths) {
+		addPathInGraph(&root, path)
+	}
+	collected := collectPathsNotInTar(&root, "")
+	sort.Strings(collected)
+	return collected
+}

--- a/nix/utils_test.go
+++ b/nix/utils_test.go
@@ -1,0 +1,35 @@
+package nix
+
+import (
+	"testing"
+	"reflect"
+)
+
+func TestPathsNotInTar(t *testing.T) {
+	paths := []string{
+		"../data/file1",
+		"../data/file2",
+		"/nix/store/1",
+		"/nix/store/1/1",
+		"/nix/store/1/1/1",
+		"/nix/store/1/1/2",
+		"/nix/store/1/2",
+		"/nix/store/1/2/1",
+		"/tmp/1/2",
+		"/nix/store/1/2/2",
+		"/nix/store/3/4/5/6",
+		"/nix/store/3/4",
+		"/nix/store/2",
+		"/nix/store/2/1",
+		"/nix/store/2/1/2",
+		"/nix/store/2/1/1",
+	}
+	expectedRoots := []string{
+		"..", "../data", "/", "/nix", "/nix/store",
+		"/nix/store/3", "/nix/store/3/4/5", "/tmp", "/tmp/1",
+	}
+	roots := pathsNotInTar(paths)
+	if !reflect.DeepEqual(roots, expectedRoots) {
+		t.Fatalf("%#v while should be %#v", roots, expectedRoots)
+	}
+}


### PR DESCRIPTION
We actually create all intermediate directories and set their
permissions to 755.

Fixes https://github.com/nlewo/nix2container/issues/12