### PR TITLE
cmd: provide rewrites via a JSON file instead of CLI args

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.43.0
           args: -E gofmt

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
-	"github.com/nlewo/nix2container/types"
 	"io/ioutil"
+
+	"github.com/nlewo/nix2container/types"
 )
 
 func readPermsFile(filename string) (permPaths []types.PermPath, err error) {
@@ -14,6 +15,18 @@ func readPermsFile(filename string) (permPaths []types.PermPath, err error) {
 	err = json.Unmarshal(content, &permPaths)
 	if err != nil {
 		return permPaths, err
+	}
+	return
+}
+
+func readRewritesFile(filename string) (rewritePaths []types.RewritePath, err error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return rewritePaths, err
+	}
+	err = json.Unmarshal(content, &rewritePaths)
+	if err != nil {
+		return rewritePaths, err
 	}
 	return
 }

--- a/nix/image.go
+++ b/nix/image.go
@@ -14,14 +14,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
 	"github.com/containers/image/v5/manifest"
 	"github.com/nlewo/nix2container/types"
 	godigest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
-	"io"
-	"io/ioutil"
-	"os"
 )
 
 // GetConfigBlob returns the config blog of an image.

--- a/nix/tar_test.go
+++ b/nix/tar_test.go
@@ -1,8 +1,9 @@
 package nix
 
 import (
-	"github.com/nlewo/nix2container/types"
 	"testing"
+
+	"github.com/nlewo/nix2container/types"
 )
 
 func TestTar(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -25,9 +25,9 @@ type Rewrite struct {
 // mainly used to move storepaths from the /nix/store to / in the
 // image.
 type RewritePath struct {
-	Path  string
-	Regex string
-	Repl  string
+	Path  string `json:"path"`
+	Regex string `json:"regex"`
+	Repl  string `json:"repl"`
 }
 
 type Perm struct {


### PR DESCRIPTION
This is to homogeneise the CLI: almost all others arguments are JSON files.