### PR TITLE
Add initializeNixDatabase argument to buildImage

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -9,4 +9,5 @@
   openbar = pkgs.callPackage ./openbar.nix { inherit nix2container; };
   layered = pkgs.callPackage ./layered.nix { inherit nix2container; };
   nested = pkgs.callPackage ./nested.nix { inherit nix2container; };
+  nix = pkgs.callPackage ./nix.nix { inherit nix2container; };
 }

--- a/examples/nix.nix
+++ b/examples/nix.nix
@@ -1,0 +1,25 @@
+{ pkgs, nix2container }:
+nix2container.buildImage {
+  name = "nix";
+  initializeNixDatabase = true;
+  contents = [
+    # nix-store uses cat program to display results as specified by
+    # the image env variable NIX_PAGER.
+    (pkgs.symlinkJoin { name = "root"; paths = [ pkgs.coreutils pkgs.nix pkgs.bash ]; })
+  ];
+  config = {
+    Env = [
+      "NIX_PAGER=cat"
+      # A user is required by nix
+      # https://github.com/NixOS/nix/blob/9348f9291e5d9e4ba3c4347ea1b235640f54fd79/src/libutil/util.cc#L478
+      "USER=nobody"
+    ];
+  };
+  # This is to check store path in nested layers are also added to the
+  # Nix database.
+  layers = [
+    (nix2container.buildLayer {
+      deps = [ pkgs.hello ];
+    })
+  ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -56,6 +56,21 @@ let
       image = examples.nested;
       pattern = "Hello, world";
     };
+    # Ensure the Nix database is correctly initialized by querying the
+    # closure of the Nix binary.
+    nix = testScript {
+      image = examples.nix;
+      command = "nix-store -qR ${pkgs.nix}";
+      pattern = "${pkgs.nix}";
+    };
+    # Ensure the Nix database is correctly initialized by querying the
+    # closure of the Nix binary.
+    # The store path is in a dedicated layer
+    nixNested = testScript {
+      image = examples.nix;
+      command = "nix-store -qR ${pkgs.hello}";
+      pattern = "${pkgs.hello}";
+    };
     # The /nix have to be explicitly present in the archive with 755 perms
     nonRegressionIssue12 = pkgs.runCommand "test-script" { buildInputs = [pkgs.jq pkgs.gnutar]; } ''
       set -e


### PR DESCRIPTION
This allows to initialize the Nix database into the image in order to
be able to use Nix from the container.

The behavior is similar to `dockerTools.buildImageWithNixDB`.

- [x] add a test with a more complex image (with `layers` especially)