### PR TITLE
copyToRegistry: only upload if the image doesn't exist on the remote

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,7 @@ let
 
   copyToRegistry = image: pkgs.writeShellScriptBin "copy-to-registry" ''
     echo "Copy to Docker registry image ${image.imageName}:${image.imageTag}"
+    ${skopeo-nix2container}/bin/skopeo --insecure-policy inspect docker://${image.imageName}:${image.imageTag} ||
     ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:${image.imageTag} $@
   '';
 


### PR DESCRIPTION
Skopeo seems to reupload the image layers each time even if the image already exists. This is less than ideal when runnig this script in environments like CI.

I considered adding a new function `maybeCopyToRegistry` instead, but this seems reasonable as the default behavior.