### PR TITLE
Rename contents to copyToRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,22 @@ Function arguments are:
     defined in the [OCI image
     specification](https://github.com/opencontainers/image-spec/blob/8b9d41f48198a7d6d0a5c1a12dc2d1f7f47fc97f/specs-go/v1/config.go#L23).
 
-- **`contents`** (defaults to `[]`): a list of store paths to include in
-    the layer root directory (store path prefixes
-    `/nix/store/hash-path` are removed, to relocate it at the image
-    `/`).
+- **`copyToRoot`** (defaults to `null`): a derivation (or list of
+    derivations) copied in the image root directory (store path
+    prefixes `/nix/store/hash-path` are removed, in order to relocate
+    them at the image `/`).
 
-- **`fromImage`** (defaults to `none`): an image that is used as base
+    `pkgs.buildEnv` can be used to build a derivation which has to be copied to
+    the image root. For instance, to get bash and coreutils in the image `/bin`:
+    ```
+    copyToRoot = pkgs.buildEnv {
+      name = "root";
+      paths = [ pkgs.bashInteractive pkgs.coreutils ];
+      pathsToLink = [ "/bin" ];
+    };
+    ```
+
+- **`fromImage`** (defaults to `null`): an image that is used as base
     image of this image.
 
 - **`maxLayers`** (defaults to `1`): the maximum number of layers to
@@ -143,10 +153,20 @@ Function arguments are:
 - **`deps`** (defaults to `[]`): a list of store paths to include in the
     layer.
 
-- **`contents`** (defaults to `[]`): a list of store paths to include in
-    the layer root directory (store path prefixes
-    `/nix/store/hash-path` are removed, to relocate it at the image
-    `/`).
+- **`copyToRoot`** (defaults to `null`): a derivation (or list of
+    derivations) copied in the image root directory (store path
+    prefixes `/nix/store/hash-path` are removed, in order to relocate
+    them at the image `/`).
+
+    `pkgs.buildEnv` can be used to build a derivation which has to be copied to
+    the image root. For instance, to get bash and coreutils in the image `/bin`:
+    ```
+    copyToRoot = pkgs.buildEnv {
+      name = "root";
+      paths = [ pkgs.bashInteractive pkgs.coreutils ];
+      pathsToLink = [ "/bin" ];
+    };
+    ```
 
 - **`reproducible`** (defaults to `true`): If `false`, the layer tarball
     is stored in the store path. This is useful when the layer

--- a/examples/bash.nix
+++ b/examples/bash.nix
@@ -1,12 +1,16 @@
 { pkgs, nix2container }:
 nix2container.buildImage {
   name = "bash";
-  contents = [
+  copyToRoot = [
     # When we want tools in /, we need to symlink them in order to
     # still have libraries in /nix/store. This behavior differs from
     # dockerTools.buildImage but this allows to avoid having files
     # in both / and /nix/store.
-    (pkgs.symlinkJoin { name = "root"; paths = [ pkgs.bashInteractive pkgs.coreutils ]; })
+    (pkgs.buildEnv {
+      name = "root";
+      paths = [ pkgs.bashInteractive pkgs.coreutils ];
+      pathsToLink = [ "/bin" ];
+    })
   ];
   config = {
     Cmd = [ "/bin/bash" ];

--- a/examples/nginx.nix
+++ b/examples/nginx.nix
@@ -28,7 +28,7 @@ let
 in
   nix2container.buildImage {
     name = "nginx";
-    contents = [
+    copyToRoot = [
       pkgs.dockerTools.fakeNss
       nginxVar
     ];

--- a/examples/nix.nix
+++ b/examples/nix.nix
@@ -2,10 +2,14 @@
 nix2container.buildImage {
   name = "nix";
   initializeNixDatabase = true;
-  contents = [
+  copyToRoot = [
     # nix-store uses cat program to display results as specified by
     # the image env variable NIX_PAGER.
-    (pkgs.symlinkJoin { name = "root"; paths = [ pkgs.coreutils pkgs.nix pkgs.bash ]; })
+    (pkgs.buildEnv {
+      name = "root";
+      paths = [ pkgs.coreutils pkgs.nix pkgs.bash ];
+      pathsToLink = "/bin";
+    })
   ];
   config = {
     Env = [

--- a/examples/openbar.nix
+++ b/examples/openbar.nix
@@ -9,7 +9,7 @@ in
 
 nix2container.buildImage {
   name = "openbar";
-  contents = [ tmp ];
+  copyToRoot = [ tmp ];
   perms = [
     {
       path = tmp;


### PR DESCRIPTION
Since the nix2container beginning, the nix2container contents behavior
differed from the dockerTools.buildImage behavior.

See https://github.com/NixOS/nixpkgs/pull/179801 for details.