### PR TITLE
fix: evaluates perms regular expression when applying permissions

### DIFF
--- a/examples/from-image.nix
+++ b/examples/from-image.nix
@@ -2,7 +2,7 @@
   alpine = nix2container.pullImage {
     imageName = "alpine";
     imageDigest = "sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178";
-    sha256 = "sha256-o4GvFCq6pvzASvlI5BLnk+Y4UN6qKL2dowuT0cp8q7Q=";
+    sha256 = "sha256-UHUcZBsoZ+DpAxroGPHkJ848sI9BF3iUia8RvUkfEC0=";
   };
 in
 nix2container.buildImage {

--- a/examples/from-image.nix
+++ b/examples/from-image.nix
@@ -2,7 +2,8 @@
   alpine = nix2container.pullImage {
     imageName = "alpine";
     imageDigest = "sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178";
-    sha256 = "sha256-UHUcZBsoZ+DpAxroGPHkJ848sI9BF3iUia8RvUkfEC0=";
+    arch = "amd64";
+    sha256 = "sha256-o4GvFCq6pvzASvlI5BLnk+Y4UN6qKL2dowuT0cp8q7Q=";
   };
 in
 nix2container.buildImage {

--- a/examples/perms.nix
+++ b/examples/perms.nix
@@ -1,0 +1,19 @@
+{ pkgs, nix2container }:
+let
+  test = pkgs.runCommand "test" { } ''
+    mkdir -p $out/tmp
+    touch $out/tmp/test1.txt
+    touch $out/tmp/test2.txt
+  '';
+in nix2container.buildImage {
+  name = "perms";
+  config.entrypoint = "${pkgs.coreutils}/bin/ls -l /tmp/";
+  copyToRoot = [ test ];
+  perms = [
+    {
+      path = test;
+      regex = "";
+      mode = "0777";
+    }
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         };
         tests = import ./tests {
           inherit pkgs examples;
+          inherit (nix2container) nix2container;
         };
       in
         rec {

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -107,7 +107,7 @@ func appendFileToTar(tw *tar.Writer, tarHeaders *tarHeaders, path string, info o
 
 	if opts != nil {
 		for _, perms := range opts.Perms {
-			re := regexp.MustCompile(opts.Rewrite.Regex)
+			re := regexp.MustCompile(perms.Regex)
 			if re.Match([]byte(path)) {
 				_, err := fmt.Sscanf(perms.Mode, "%o", &hdr.Mode)
 				if err != nil {


### PR DESCRIPTION
Fixes #45 

I ran the same sample code provided in the issue with this fix applied and got the expected results (no file permissions modified). 