### PR TITLE
feat: adds support for overriding path owner

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -10,4 +10,5 @@
   layered = pkgs.callPackage ./layered.nix { inherit nix2container; };
   nested = pkgs.callPackage ./nested.nix { inherit nix2container; };
   nix = pkgs.callPackage ./nix.nix { inherit nix2container; };
+  ownership = pkgs.callPackage ./ownership.nix { inherit nix2container; };
 }

--- a/examples/ownership.nix
+++ b/examples/ownership.nix
@@ -1,0 +1,21 @@
+{ pkgs, nix2container }:
+let
+  test = pkgs.runCommand "test" { } ''
+    mkdir -p $out/tmp
+    touch $out/tmp/test1.txt
+    touch $out/tmp/test2.txt
+  '';
+in
+nix2container.buildImage {
+  name = "ownership";
+  config.entrypoint = [ "${pkgs.coreutils}/bin/ls" "-l" "/tmp/" ];
+  copyToRoot = [ test ];
+  perms = [
+    {
+      path = test;
+      regex = "/tmp/test1.txt";
+      uid = 1001;
+      gid = 1001;
+    }
+  ];
+}

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -26,6 +26,10 @@ func getPaths(storePaths []string, parents []types.Layer, rewrites []types.Rewri
 				perms = append(perms, types.Perm{
 					Regex: perm.Regex,
 					Mode:  perm.Mode,
+					Uid:   perm.Uid,
+					Gid:   perm.Gid,
+					Uname: perm.Uname,
+					Gname: perm.Gname,
 				})
 			}
 		}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -121,9 +121,11 @@ func appendFileToTar(tw *tar.Writer, tarHeaders *tarHeaders, path string, info o
 					hdr.Gname = perms.Uname
 				}
 
-				_, err := fmt.Sscanf(perms.Mode, "%o", &hdr.Mode)
-				if err != nil {
-					return err
+				if perms.Mode != "" {
+					_, err := fmt.Sscanf(perms.Mode, "%o", &hdr.Mode)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -109,6 +109,11 @@ func appendFileToTar(tw *tar.Writer, tarHeaders *tarHeaders, path string, info o
 		for _, perms := range opts.Perms {
 			re := regexp.MustCompile(perms.Regex)
 			if re.Match([]byte(path)) {
+				hdr.Uid = perms.Uid
+				hdr.Gid = perms.Gid
+				hdr.Uname = perms.Uname
+				hdr.Gname = perms.Gname
+
 				_, err := fmt.Sscanf(perms.Mode, "%o", &hdr.Mode)
 				if err != nil {
 					return err

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -109,10 +109,17 @@ func appendFileToTar(tw *tar.Writer, tarHeaders *tarHeaders, path string, info o
 		for _, perms := range opts.Perms {
 			re := regexp.MustCompile(perms.Regex)
 			if re.Match([]byte(path)) {
+				// Zero value is same as root ID (0)
 				hdr.Uid = perms.Uid
 				hdr.Gid = perms.Gid
-				hdr.Uname = perms.Uname
-				hdr.Gname = perms.Gname
+
+				if perms.Uname != "" {
+					hdr.Uname = perms.Uname
+				}
+
+				if perms.Gname != "" {
+					hdr.Gname = perms.Uname
+				}
 
 				_, err := fmt.Sscanf(perms.Mode, "%o", &hdr.Mode)
 				if err != nil {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -56,6 +56,10 @@ let
       image = examples.nested;
       pattern = "Hello, world";
     };
+    ownership = testScript {
+      image = examples.ownership;
+      pattern = "^-r--r--r-- 1 1001 1001 0 Jan  1  1970 test1.txt";
+    };
     # Ensure the Nix database is correctly initialized by querying the
     # closure of the Nix binary.
     nix = testScript {

--- a/types/types.go
+++ b/types/types.go
@@ -34,14 +34,22 @@ type RewritePath struct {
 type Perm struct {
 	Regex string `json:"regex"`
 	// Octal representation of file permissions
-	Mode string `json:"mode"`
+	Mode  string `json:"mode"`
+	Uid   int    `json:"uid"`
+	Gid   int    `json:"gid"`
+	Uname string `json:"uname"`
+	Gname string `json:"gname"`
 }
 
 type PermPath struct {
 	Path  string `json:"path"`
 	Regex string `json:"regex"`
 	// Octal representation of file permissions
-	Mode string `json:"mode"`
+	Mode  string `json:"mode"`
+	Uid   int    `json:"uid"`
+	Gid   int    `json:"gid"`
+	Uname string `json:"uname"`
+	Gname string `json:"gname"`
 }
 
 type PathOptions struct {


### PR DESCRIPTION
Fixes #44 

This PR adds four new fields: `Uid`, `Gid`, `Uname`, and `Gname`. They allow modifying their respective ownership permissions on paths. The default behavior of keeping non-matched files as "0/0/root/root" is maintained for backward compatibility. The only other change is that specifying `mode` is now optional; this is to allow changing ownership while still keeping the default umask. 

This PR includes the permission fix from #46. Feel free to close that one and merge this if it makes things cleaner.