### PR TITLE
Add the build flag useNixCaseHack

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }, system }:
 let
   l = pkgs.lib // builtins;
 
@@ -21,9 +21,14 @@ let
       );
     };
     vendorSha256 = "sha256-/j4ZHOwU5Xi8CE/fHha+2iZhsLd/y2ovzVhvg8HDV78=";
+    ldflags = pkgs.lib.optional pkgs.stdenv.isDarwin [
+      "-X github.com/nlewo/nix2container/nix.useNixCaseHack=true"
+    ];
+
   };
 
   skopeo-nix2container = pkgs.skopeo.overrideAttrs (old: {
+    EXTRA_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin "-X github.com/nlewo/nix2container/nix.useNixCaseHack=true";
     preBuild = let
       patch = pkgs.fetchurl {
         url = "https://github.com/Mic92/image/commit/b3cb51066518ed2c6f6c8cf0cb4ae1e84f68b5ce.patch";

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         nix2container = import ./. {
-          inherit pkgs;
+          inherit pkgs system;
         };
         examples = import ./examples {
           inherit pkgs;

--- a/nix/tar_test.go
+++ b/nix/tar_test.go
@@ -24,3 +24,21 @@ func TestTar(t *testing.T) {
 		t.Errorf("Size is %d while it should be %d", size, expectedSize)
 	}
 }
+
+func TestRemoveNixCaseHackSuffix(t *testing.T) {
+	ret := removeNixCaseHackSuffix("filename~nix~case~hack~1")
+	expected := "filename"
+	if ret != expected {
+		t.Errorf("%s should be %s", ret, expected)
+	}
+	ret = removeNixCaseHackSuffix("/path~nix~case~hack~1/filename")
+	expected = "/path/filename"
+	if ret != expected {
+		t.Errorf("%s should be %s", ret, expected)
+	}
+	ret = removeNixCaseHackSuffix("filename~nix~")
+	expected = "filename~nix~"
+	if ret != expected {
+		t.Errorf("%s should be %s", ret, expected)
+	}
+}

--- a/nix/utils.go
+++ b/nix/utils.go
@@ -2,10 +2,30 @@ package nix
 
 import (
 	"github.com/nlewo/nix2container/types"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 )
+
+func removeNixCaseHackSuffix(filepath string) string {
+	caseHackSuffix := "~nix~case~hack~"
+	parts := strings.Split(filepath, "/")
+	cleaned := make([]string, len(parts))
+	for i, part := range parts {
+		idx := strings.Index(part, caseHackSuffix)
+		if idx != -1 {
+			cleaned[i] = part[0:idx]
+		} else {
+			cleaned[i] = part
+		}
+	}
+	var prefix string
+	if strings.HasPrefix(filepath, "/") {
+		prefix = "/"
+	}
+	return prefix + path.Join(cleaned...)
+}
 
 func splitPath(path string) []string {
 	cleaned := filepath.Clean(path)


### PR DESCRIPTION
This build flag allows to publish an image on a case insensitive FS. Otherwise, hash can differs as detailled in
https://github.com/nlewo/nix2container/issues/37

Fixes !37

@nktpro it would be nice if you could test if it fix your issue?

I still need to ensure it's a good idea to always patch the `nix2container` binary and Skopeo on Darwin... TBH, i'm a bit confused with multiarch containers which are built and pushed on different architectures :upside_down_face: 