### PR TITLE
feat: allows controlling ownership of /nix

### DIFF
--- a/examples/default.nix
+++ b/examples/default.nix
@@ -10,5 +10,6 @@
   layered = pkgs.callPackage ./layered.nix { inherit nix2container; };
   nested = pkgs.callPackage ./nested.nix { inherit nix2container; };
   nix = pkgs.callPackage ./nix.nix { inherit nix2container; };
+  nix-user = pkgs.callPackage ./nix-user.nix { inherit nix2container; };
   ownership = pkgs.callPackage ./ownership.nix { inherit nix2container; };
 }

--- a/examples/nix-user.nix
+++ b/examples/nix-user.nix
@@ -1,0 +1,74 @@
+{ pkgs, nix2container }:
+let
+  l = pkgs.lib // builtins;
+
+  user = "user";
+  group = "user";
+  uid = "1000";
+  gid = "1000";
+
+  mkUser = pkgs.runCommand "mkUser" { } ''
+    mkdir -p $out/etc/pam.d
+
+    echo "${user}:x:${uid}:${gid}::" > $out/etc/passwd
+    echo "${user}:!x:::::::" > $out/etc/shadow
+
+    echo "${group}:x:${gid}:" > $out/etc/group
+    echo "${group}:x::" > $out/etc/gshadow
+
+    cat > $out/etc/pam.d/other <<EOF
+    account sufficient pam_unix.so
+    auth sufficient pam_rootok.so
+    password requisite pam_unix.so nullok sha512
+    session required pam_unix.so
+    EOF
+
+    touch $out/etc/login.defs
+    mkdir -p $out/home/${user}
+  '';
+
+  entrypoint = pkgs.writeShellApplication
+    {
+      name = "entrypoint";
+      text = ''
+        (nix doctor && ls -la /nix) >out 2>&1 && cat out
+      '';
+    };
+in
+nix2container.buildImage {
+  name = "nix-user";
+  tag = "latest";
+
+  initializeNixDatabase = true;
+  nixUid = l.toInt uid;
+  nixGid = l.toInt gid;
+
+  copyToRoot = [
+    (pkgs.buildEnv {
+      name = "root";
+      paths = [ pkgs.coreutils pkgs.nix ];
+      pathsToLink = "/bin";
+    })
+    mkUser
+  ];
+
+  perms = [{
+    path = mkUser;
+    regex = "/home/${user}";
+    mode = "0744";
+    uid = l.toInt uid;
+    gid = l.toInt gid;
+    uname = user;
+    gname = group;
+  }];
+
+  config = {
+    entrypoint = [ "${entrypoint}/bin/entrypoint" ];
+    Env = [
+      "HOME=/home/user"
+      "NIX_PAGER=cat"
+      "USER=user"
+    ];
+  };
+}
+

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,10 +4,11 @@ let
   testScript = {
     image,
     command ? "",
+    grepFlags ? "",
     pattern,
   }: pkgs.writeScriptBin "test-script" ''
     ${image.copyToPodman}/bin/copy-to-podman
-    ${pkgs.podman}/bin/podman run ${image.imageName}:${image.imageTag} ${command} | grep '${pattern}'
+    ${pkgs.podman}/bin/podman run ${image.imageName}:${image.imageTag} ${command} | ${pkgs.gnugrep}/bin/grep ${grepFlags} '${pattern}'
     ret=$?
     if [ $ret -ne 0 ];
     then
@@ -66,6 +67,11 @@ let
       image = examples.nix;
       command = "nix-store -qR ${pkgs.nix}";
       pattern = "${pkgs.nix}";
+    };
+    nix-user = testScript {
+      image = examples.nix-user;
+      grepFlags = "-Pz";
+      pattern = "(?s)\[PASS].*\[PASS].*\[PASS].*drwx------ \\d+ user user 4096 Jan  1  1970 store";
     };
     # Ensure the Nix database is correctly initialized by querying the
     # closure of the Nix binary.


### PR DESCRIPTION
Fixes #50 

Adds two new arguments to `buildImage` which allow controlling ownership of `/nix`. By default, the ownership stays with root if the arguments are not specified. 

The only other change this introduces is moving the `customizationLayer` to the end of the layer list instead of the beginning. This ensures that ownership of `/nix/store` remains with the desired user. As far as I know, this shouldn't be a breaking change. All tests are passing. 