### PR TITLE
fix: fix wrong permissions when initializing nix database

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -298,7 +298,7 @@ let
         {
           path = nixDatabase;
           regex = ".*";
-          mode = "0700";
+          mode = "0755";
           uid = nixUid;
           gid = nixGid;
         }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -71,7 +71,7 @@ let
     nix-user = testScript {
       image = examples.nix-user;
       grepFlags = "-Pz";
-      pattern = "(?s)\[PASS].*\[PASS].*\[PASS].*drwx------ \\d+ user user 4096 Jan  1  1970 store";
+      pattern = "(?s)\[PASS].*\[PASS].*\[PASS].*drwxr-xr-x \\d+ user user 4096 Jan  1  1970 store";
     };
     # Ensure the Nix database is correctly initialized by querying the
     # closure of the Nix binary.


### PR DESCRIPTION
The `0700` permissions are too restrictive and prevent other users from executing stuff in the store. 