### PR TITLE
feat: adds support for extra tags

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,11 +50,29 @@ let
     echo "Copy to Docker daemon image ${image.imageName}:${image.imageTag}"
     ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker-daemon:${image.imageName}:${image.imageTag}
     ${skopeo-nix2container}/bin/skopeo --insecure-policy inspect docker-daemon:${image.imageName}:${image.imageTag}
+
+    # Push extra tags if present
+    if [[ ! -z "${l.concatStringsSep " " image.imageExtraTags}" ]]; then
+      for tag in ${l.concatStringsSep " " image.imageExtraTags}
+      do
+        echo "Copy to Docker daemon image ${image.imageName}:$tag"
+        ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker-daemon:${image.imageName}:$tag
+      done
+    fi
   '';
 
   copyToRegistry = image: pkgs.writeShellScriptBin "copy-to-registry" ''
     echo "Copy to Docker registry image ${image.imageName}:${image.imageTag}"
-    ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:${image.imageTag} $@
+    #${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:${image.imageTag} $@
+
+    # Push extra tags if present
+    if [[ ! -z "${l.concatStringsSep " " image.imageExtraTags}" ]]; then
+      for tag in ${l.concatStringsSep " " image.imageExtraTags}
+      do
+        echo "Copy to Docker registry image ${image.imageName}:$tag"
+        #${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:$tag $@
+      done
+    fi
   '';
 
   copyTo = image: pkgs.writeShellScriptBin "copy-to" ''
@@ -66,6 +84,15 @@ let
     echo "Copy to podman image ${image.imageName}:${image.imageTag}"
     ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} containers-storage:${image.imageName}:${image.imageTag}
     ${skopeo-nix2container}/bin/skopeo --insecure-policy inspect containers-storage:${image.imageName}:${image.imageTag}
+
+    # Push extra tags if present
+    if [[ ! -z "${l.concatStringsSep " " image.imageExtraTags}" ]]; then
+      for tag in ${l.concatStringsSep " " image.imageExtraTags}
+      do
+        echo "Copy to podman image ${image.imageName}:$tag"
+        ${skopeo-nix2container}/bin/skopeo --insecure-policy copy nix:${image} containers-storage:${image.imageName}:$tag
+      done
+    fi
   '';
 
   # Pull an image from a registry with Skopeo and translate it to a
@@ -240,6 +267,8 @@ let
     name,
     # Image tag, when null then the nix output hash will be used.
     tag ? null,
+    # Additional tags to use when copying image to registry
+    extraTags ? [],
     # An attribute set describing an image configuration as defined in
     # https://github.com/opencontainers/image-spec/blob/8b9d41f48198a7d6d0a5c1a12dc2d1f7f47fc97f/specs-go/v1/config.go#L23
     config ? {},
@@ -333,6 +362,7 @@ let
         inherit imageName;
         passthru = {
           inherit imageTag;
+          imageExtraTags = extraTags;
           # provide a cheap to evaluate image reference for use with external tools like docker
           # DO NOT use as an input to other derivations, as there is no guarantee that the image
           # reference will exist in the store.


### PR DESCRIPTION
Solves #59. It should be backward compatible since it adds an `extraTags` argument to `buildImage`. If omitted, the default logic of just pushing the single tag is retained. 