### PR TITLE
Inject missing rootfs type "layers" in container metadata

### DIFF
--- a/nix/image.go
+++ b/nix/image.go
@@ -82,6 +82,7 @@ func getV1Image(image types.Image) (imageV1 v1.Image, err error) {
 		imageV1.RootFS.DiffIDs = append(
 			imageV1.RootFS.DiffIDs,
 			digest)
+		imageV1.RootFS.Type = "layers"
 		imageV1.History = append(
 			imageV1.History,
 			v1.History{

--- a/nix/image_test.go
+++ b/nix/image_test.go
@@ -48,6 +48,7 @@ func TestGetV1Image(t *testing.T) {
 		RootFS: v1.RootFS{
 			DiffIDs: []digest.Digest{
 				"sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27"},
+			Type: "layers",
 		},
 		History: []v1.History{
 			{


### PR DESCRIPTION
The current behavior is to leave the ImageV1 `rootfs.type` empty. This leads to some error with external tools like Singularity which fail to run the image.

Setting the Rootfs type in the image metadata to "layers" is mandatory according to the documentation:
https://github.com/opencontainers/image-spec/blob/main/config.md?plain=1#L210-L218  