### PR TITLE
Fixes #94: do not include config file in nix database.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -289,9 +289,11 @@ let
         | head -n -1 \
         | ${pkgs.nix}/bin/nix-store --load-db -j 1
 
+      # Sanitize time stamps
       sqlite3 $PWD/nix/var/nix/db/db.sqlite \
         'UPDATE ValidPaths SET registrationTime = 0;';
 
+      # Dump and reimport to ensure that the update order doesn't somehow change the DB.
       sqlite3 $PWD/nix/var/nix/db/db.sqlite '.dump' > db.dump
       mkdir -p $out/nix/var/nix/db/
       sqlite3 $out/nix/var/nix/db/db.sqlite '.read db.dump'


### PR DESCRIPTION
`closureGraph` is extended with an ignore argument which will filter out the config file when needed.

The resulting graph is both passed to nix2container-bin and makeNixDatabase -- ensuring that both contain the same paths.

The `--ignore` flag of the nix2container-bin is not used anymore.

https://github.com/nlewo/nix2container/issues/94