### PR TITLE
Refactor nix files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,21 @@ post](https://lewo.abesis.fr/posts/nix-build-container-image/).
 ```nix
 {
   inputs.nix2container.url = "github:nlewo/nix2container";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
-  outputs = { self, nixpkgs, nix2container }: let
-    pkgs = import nixpkgs { system = "x86_64-linux"; };
-    nix2containerPkgs = nix2container.packages.x86_64-linux;
-  in {
-    packages.x86_64-linux.hello = nix2containerPkgs.nix2container.buildImage {
+  outputs = inputs: inputs.flake-utils.lib.eachDefaultSystem (system:
+  let 
+    pkgs = import inputs.nixpkgs { inherit system; overlays = [ inputs.nix2container.overlays.default ] ;};
+    packages.hello = pkgs.nix2container.buildImage {
       name = "hello";
       config = {
         entrypoint = ["${pkgs.hello}/bin/hello"];
       };
     };
-  };
+  in 
+    { inherit packages; }
+  )
 }
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -427,6 +427,5 @@ let
         ;
 in
 {
-  inherit nix2container-bin skopeo-nix2container;
-  nix2container = { inherit buildImage buildLayer pullImage pullImageFromManifest; };
+  inherit nix2container-bin skopeo-nix2container buildImage buildLayer pullImage pullImageFromManifest;
 }

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -1,17 +1,17 @@
-{ pkgs, nix2container }: {
-  hello = pkgs.callPackage ./hello.nix { inherit nix2container; };
-  nginx = pkgs.callPackage ./nginx.nix { inherit nix2container; };
-  bash = pkgs.callPackage ./bash.nix { inherit nix2container; };
-  basic = pkgs.callPackage ./basic.nix { inherit nix2container; };
-  nonReproducible = pkgs.callPackage ./non-reproducible.nix { inherit nix2container; };
-  fromImage = pkgs.callPackage ./from-image.nix { inherit nix2container; };
-  fromImageManifest = pkgs.callPackage ./from-image-manifest.nix { inherit nix2container; };
-  getManifest = pkgs.callPackage ./get-manifest.nix { inherit nix2container; };
-  uwsgi = pkgs.callPackage ./uwsgi { inherit nix2container; };
-  openbar = pkgs.callPackage ./openbar.nix { inherit nix2container; };
-  layered = pkgs.callPackage ./layered.nix { inherit nix2container; };
-  nested = pkgs.callPackage ./nested.nix { inherit nix2container; };
-  nix = pkgs.callPackage ./nix.nix { inherit nix2container; };
-  nix-user = pkgs.callPackage ./nix-user.nix { inherit nix2container; };
-  ownership = pkgs.callPackage ./ownership.nix { inherit nix2container; };
+{ pkgs }: {
+  hello = pkgs.callPackage ./hello.nix { };
+  nginx = pkgs.callPackage ./nginx.nix { };
+  bash = pkgs.callPackage ./bash.nix { };
+  basic = pkgs.callPackage ./basic.nix { };
+  nonReproducible = pkgs.callPackage ./non-reproducible.nix { };
+  fromImage = pkgs.callPackage ./from-image.nix { };
+  fromImageManifest = pkgs.callPackage ./from-image-manifest.nix { };
+  getManifest = pkgs.callPackage ./get-manifest.nix { };
+  uwsgi = pkgs.callPackage ./uwsgi { };
+  openbar = pkgs.callPackage ./openbar.nix { };
+  layered = pkgs.callPackage ./layered.nix { };
+  nested = pkgs.callPackage ./nested.nix { };
+  nix = pkgs.callPackage ./nix.nix { };
+  nix-user = pkgs.callPackage ./nix-user.nix { };
+  ownership = pkgs.callPackage ./ownership.nix { };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,32 +5,33 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
   outputs = inputs:
-    inputs.flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays.default = final: prev: {
-          nix2container = import ./. { system = final.system; pkgs = prev; };
-        };
-        
-        pkgs = inputs.nixpkgs.legacyPackages.${system}.extend overlays.default;
-        
-        examples = pkgs.callPackage ./examples { };
-        tests = pkgs.callPackage ./tests { inherit examples; };
+    inputs.flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import inputs.nixpkgs { inherit system; overlays = [ inputs.self.overlays.default ]; };
 
-        packages = {
-          inherit (pkgs.nix2container) nix2container-bin skopeo-nix2container;
-          inherit examples tests;
-          default = packages.nix2container-bin;
-          hello = pkgs.nix2container.buildImage {
-            name = "hello";
-            config = {
-              entrypoint = [ "${pkgs.hello}/bin/hello" ];
+          examples = pkgs.callPackage ./examples { };
+          tests = pkgs.callPackage ./tests { inherit examples; };
+
+          packages = {
+            inherit (pkgs.nix2container) nix2container-bin skopeo-nix2container;
+            inherit examples tests;
+            default = packages.nix2container-bin;
+            hello = pkgs.nix2container.buildImage {
+              name = "hello";
+              config = {
+                entrypoint = [ "${pkgs.hello}/bin/hello" ];
+              };
             };
           };
-        };
-      in
-      {
-        inherit packages;
-        inherit (pkgs) nix2container;
-        inherit overlays;
-      });
+        in
+        {
+          inherit packages;
+          inherit (pkgs) nix2container;
+        })
+    // {
+      overlays.default = final: prev: {
+        nix2container = import ./. { system = final.system; pkgs = prev; };
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,27 +4,33 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs = inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        nix2container = import ./. {
-          inherit pkgs system;
+        overlays.default = final: prev: {
+          nix2container = import ./. { system = final.system; pkgs = prev; };
         };
-        examples = import ./examples {
-          inherit pkgs;
-          inherit (nix2container) nix2container;
-        };
-        tests = import ./tests {
-          inherit pkgs examples;
-          inherit (nix2container) nix2container;
+        
+        pkgs = inputs.nixpkgs.legacyPackages.${system}.extend overlays.default;
+        
+        examples = pkgs.callPackage ./examples { };
+        tests = pkgs.callPackage ./tests { inherit examples; };
+
+        packages = {
+          inherit (pkgs.nix2container) nix2container-bin skopeo-nix2container;
+          inherit examples tests;
+          default = packages.nix2container-bin;
+          hello = pkgs.nix2container.buildImage {
+            name = "hello";
+            config = {
+              entrypoint = [ "${pkgs.hello}/bin/hello" ];
+            };
+          };
         };
       in
-        rec {
-          packages = {
-            inherit (nix2container) nix2container-bin skopeo-nix2container nix2container;
-            inherit examples tests;
-          };
-          defaultPackage = packages.nix2container-bin;
-        });
+      {
+        inherit packages;
+        inherit (pkgs) nix2container;
+        inherit overlays;
+      });
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix2container, examples }:
+{ pkgs, examples, nix2container }:
 
 let
   testScript = {


### PR DESCRIPTION
- Added an overlay so that one can add `nix2container` to `pkgs`.
- Moved all attributes into `nix2container`, so that one doesn't need to write `nix2container.nix2container`.
- Simplified `callPackage` expressions using this new attrset structure
- Updated readme example
  - Discouraged shadowing by using `outputs: inputs`
  - Showed how to use the overlay