### PR TITLE
default.nix: fix evaluation on macos

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
       );
     };
     vendorSha256 = "sha256-/j4ZHOwU5Xi8CE/fHha+2iZhsLd/y2ovzVhvg8HDV78=";
-    ldflags = pkgs.lib.optional pkgs.stdenv.isDarwin [
+    ldflags = pkgs.lib.optionals pkgs.stdenv.isDarwin [
       "-X github.com/nlewo/nix2container/nix.useNixCaseHack=true"
     ];
   };


### PR DESCRIPTION
Fixes #119 