### PR TITLE
 Fix failing Skopeo pullImage with /run/containers not readable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -114,6 +114,9 @@ let
         nativeBuildInputs = l.singleton pkgs.skopeo;
         SSL_CERT_FILE = "${pkgs.cacert.out}/etc/ssl/certs/ca-bundle.crt";
 
+        XDG_RUNTIME_DIR = TMPDIR;
+
+
         sourceURL = "docker://${imageName}@${imageDigest}";
       } ''
       skopeo \


### PR DESCRIPTION
I've just debugged for someone why Skopeo fails with `reading JSON file "/run/containers/1001/auth.json": open /run/containers/1001/auth.json: permission denied` inside GitHub actions.

I think that is something also true for `nix2container.pullImage`, though I'm not sure how/where you would like me to add this change. Needs probably some further investigation.

To test this run `mkdir /run/containers; chmod 000 /run/containers` and see Skopeo pull failing.

https://github.com/NixOS/nixpkgs/pull/294849