### PR TITLE
Speed up `skopeo copy`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,7 @@ let
       mkdir -p vendor/github.com/nlewo/nix2container/
       cp -r ${nix2container-bin.src}/* vendor/github.com/nlewo/nix2container/
       cd vendor/github.com/containers/image/v5
+      substituteInPlace copy/copy.go --replace 'maxParallelDownloads = uint(6)' 'maxParallelDownloads = uint(64)'
       mkdir nix/
       touch nix/transport.go
       # The patch for alltransports.go does not apply cleanly to skopeo > 1.14,


### PR DESCRIPTION
Images produced by `nix2container` usually contains more than 100 layers. It takes a long time to decide whether each layer should be skipped. This PR makes the process faster by increase the concurrency to 64.