### PR TITLE
fix: multiple shell args

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,21 +51,22 @@ let
   writeSkopeoApplication = name: text: pkgs.writeShellApplication {
     inherit name text;
     runtimeInputs = [ pkgs.jq skopeo-nix2container ];
+    excludeShellChecks = [ "SC2068" ];
   };
 
   copyToDockerDaemon = image: writeSkopeoApplication "copy-to-docker-daemon" ''
     echo "Copy to Docker daemon image ${image.imageName}:${image.imageTag}"
-    skopeo --insecure-policy copy nix:${image} docker-daemon:${image.imageName}:${image.imageTag} "$@"
+    skopeo --insecure-policy copy nix:${image} docker-daemon:${image.imageName}:${image.imageTag} $@
   '';
 
   copyToRegistry = image: writeSkopeoApplication "copy-to-registry" ''
     echo "Copy to Docker registry image ${image.imageName}:${image.imageTag}"
-    skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:${image.imageTag} "$@"
+    skopeo --insecure-policy copy nix:${image} docker://${image.imageName}:${image.imageTag} $@
   '';
 
   copyTo = image: writeSkopeoApplication "copy-to" ''
-    echo Running skopeo --insecure-policy copy nix:${image} "$@"
-    skopeo --insecure-policy copy nix:${image} "$@"
+    echo Running skopeo --insecure-policy copy nix:${image} $@
+    skopeo --insecure-policy copy nix:${image} $@
   '';
 
   copyToPodman = image: writeSkopeoApplication "copy-to-podman" ''

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697269602,
-        "narHash": "sha256-dSzV7Ud+JH4DPVD9od53EgDrxUVQOcSj4KGjggCDVJI=",
+        "lastModified": 1712920918,
+        "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cb540e9c1910d74a7e10736277f6eb9dff51c81",
+        "rev": "92323443a56f4e9fc4e4b712e3119f66d0969297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes  #131

flake.lock change is required to use `excludeShellChecks` attribute