### PR TITLE
Change modification time to be consistent with nix store

### DIFF
--- a/nix/image_test.go
+++ b/nix/image_test.go
@@ -34,8 +34,8 @@ func TestGetV1Image(t *testing.T) {
 	image := types.Image{
 		Layers: []types.Layer{
 			{
-				Digest:    "sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27",
-				DiffIDs:   "sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27",
+				Digest:    "sha256:adf74a52f9e1bcd7dab77193455fa06743b979cf5955148010e5becedba4f72d",
+				DiffIDs:   "sha256:adf74a52f9e1bcd7dab77193455fa06743b979cf5955148010e5becedba4f72d",
 				Size:      10,
 				MediaType: "application/vnd.oci.image.layer.v1.tar",
 			},
@@ -47,7 +47,7 @@ func TestGetV1Image(t *testing.T) {
 		OS: "linux",
 		RootFS: v1.RootFS{
 			DiffIDs: []digest.Digest{
-				"sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27"},
+				"sha256:adf74a52f9e1bcd7dab77193455fa06743b979cf5955148010e5becedba4f72d"},
 			Type: "layers",
 		},
 		History: []v1.History{

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -24,8 +24,8 @@ func TestPerms(t *testing.T) {
 	}
 	expected := []types.Layer{
 		{
-			Digest:  "sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27",
-			DiffIDs: "sha256:6123adfc04c22915c112368b802af161b921fbf7ef1c5f7283191ee552b46e27",
+			Digest:  "sha256:adf74a52f9e1bcd7dab77193455fa06743b979cf5955148010e5becedba4f72d",
+			DiffIDs: "sha256:adf74a52f9e1bcd7dab77193455fa06743b979cf5955148010e5becedba4f72d",
 			Size:    3072,
 			Paths: types.Paths{
 				types.Path{
@@ -56,8 +56,8 @@ func TestNewLayers(t *testing.T) {
 	}
 	expected := []types.Layer{
 		{
-			Digest:  "sha256:f2c0df36c223df52ef1ccc9d5979b39fb03fecae111f908fc9c2bdd50d477acd",
-			DiffIDs: "sha256:f2c0df36c223df52ef1ccc9d5979b39fb03fecae111f908fc9c2bdd50d477acd",
+			Digest:  "sha256:cc45bd46eca903b0900ebb997dffd5778904dca9ec02e7375dd1e653dfb61e2e",
+			DiffIDs: "sha256:cc45bd46eca903b0900ebb997dffd5778904dca9ec02e7375dd1e653dfb61e2e",
 			Size:    3072,
 			Paths: types.Paths{
 				types.Path{
@@ -76,8 +76,8 @@ func TestNewLayers(t *testing.T) {
 	}
 	expected = []types.Layer{
 		{
-			Digest:  "sha256:f2c0df36c223df52ef1ccc9d5979b39fb03fecae111f908fc9c2bdd50d477acd",
-			DiffIDs: "sha256:f2c0df36c223df52ef1ccc9d5979b39fb03fecae111f908fc9c2bdd50d477acd",
+			Digest:  "sha256:cc45bd46eca903b0900ebb997dffd5778904dca9ec02e7375dd1e653dfb61e2e",
+			DiffIDs: "sha256:cc45bd46eca903b0900ebb997dffd5778904dca9ec02e7375dd1e653dfb61e2e",
 			Size:    3072,
 			Paths: types.Paths{
 				types.Path{
@@ -85,7 +85,7 @@ func TestNewLayers(t *testing.T) {
 				},
 			},
 			MediaType: "application/vnd.oci.image.layer.v1.tar",
-			LayerPath: tmpDir + "/f2c0df36c223df52ef1ccc9d5979b39fb03fecae111f908fc9c2bdd50d477acd.tar",
+			LayerPath: tmpDir + "/cc45bd46eca903b0900ebb997dffd5778904dca9ec02e7375dd1e653dfb61e2e.tar",
 		},
 	}
 	assert.Equal(t, expected, layer)

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -64,6 +64,9 @@ func createDirectory(tw *tar.Writer, path string) error {
 		ChangeTime: epoch,
 		Mode:       0755,
 	}
+
+	hdr.ModTime = time.Date(1970, 01, 01, 0, 0, 1, 0, time.UTC)
+
 	if err := tw.WriteHeader(hdr); err != nil {
 		return fmt.Errorf("Could not write hdr '%#v', got error '%s'", hdr, err.Error())
 	}
@@ -123,7 +126,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 		}
 	}
 
-	hdr.ModTime = time.Date(1970, 01, 01, 0, 0, 0, 0, time.UTC)
+	hdr.ModTime = time.Date(1970, 01, 01, 0, 0, 1, 0, time.UTC)
 	hdr.AccessTime = time.Date(1970, 01, 01, 0, 0, 0, 0, time.UTC)
 	hdr.ChangeTime = time.Date(1970, 01, 01, 0, 0, 0, 0, time.UTC)
 

--- a/nix/tar_test.go
+++ b/nix/tar_test.go
@@ -15,7 +15,7 @@ func TestTar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	expectedDigest := "sha256:25561a5f9e53bfd69476c622953dee27868291dd67c478b499da6a1962893bb4"
+	expectedDigest := "sha256:1ea63d00b937dc24c711265b80444cc9e7e63751fb7f349b160be61d31381983"
 	assert.Equal(t, expectedDigest, digest.String())
 
 	expectedSize := int64(4096)


### PR DESCRIPTION
I investigated why my nginx worked fine on my host nixos but not in the container. I found that nginx is patched to better handle files inside the nix store, but one of the condition is that mtime should be 1. I checked /nix/store on my system and yes all files have mtime 1, then I checked /nix/store files inside the container and mtime is 0

 https://github.com/NixOS/nixpkgs/blob/194846768975b7ad2c4988bdb82572c00222c0d7/pkgs/servers/http/nginx/nix-etag-1.15.4.patch#L43

After changing modification time from 0 to 1 in the nix2container that patch started to work as expected