### PR TITLE
Update the Skopeo patch hash

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ let
     preBuild = let
       patch = pkgs.fetchurl {
         url = "https://github.com/nlewo/image/commit/c2254c998433cf02af60bf0292042bd80b96a77e.patch";
-        sha256 = "sha256-dKEObfZY2fdsza/kObCLhv4l2snuzAbpDi4fGmtTPUQ=";
+        sha256 = "sha256-1Tj9D+ePjGL5u04aT7zr5rJw4vHAVrXAsr4owdooC/Y=";
 
       };
     in ''


### PR DESCRIPTION
It looks like GitHub changed the way their are generating patches. Here are differences:

    diff c2254c998433cf02af60bf0292042bd80b96a77e.patch /nix/store/xk6z74qc073dvs1ngvk58qqby73q6yx9-c2254c998433cf02af60bf0292042bd80b96a77e.patch
    18c18
    < index 0000000000..46e737dc78
    ---
    > index 000000000..46e737dc7
    229c229
    < index 0bae8b2599..34cf925c29 100644
    ---
    > index 0bae8b259..34cf925c2 100644