### PR TITLE
fix: stable patch fetch

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,10 +29,23 @@ let
     EXTRA_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin "-X github.com/nlewo/nix2container/nix.useNixCaseHack=true";
     nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.patchutils ];
     preBuild = let
-      patch = pkgs.fetchurl {
+      # Needs to use fetchpatch2 to handle "git extended headers", which include
+      # lines with semantic content like "rename from" and "rename to".
+      # However, it also includes "index" lines which include the git revision(s) the patch was initially created from.
+      # These lines may include revisions of differing length, based on how Github generates them.
+      # fetchpatch2 does not filter out, but probably should    
+      fetchgitpatch = args: pkgs.fetchpatch2 (args // {
+        postFetch = (args.postFetch or "") + ''
+          sed -i \
+            -e '/^index /d' \
+            -e '/^similarity index /d' \
+            -e '/^dissimilarity index /d' \
+            $out
+        '';
+      });
+      patch = fetchgitpatch {
         url = "https://github.com/nlewo/image/commit/c2254c998433cf02af60bf0292042bd80b96a77e.patch";
-        sha256 = "sha256-1Tj9D+ePjGL5u04aT7zr5rJw4vHAVrXAsr4owdooC/Y=";
-
+        sha256 = "sha256-6CUjz46xD3ORgwrHwdIlSu6JUj7WLS6BOSyRGNnALHY=";
       };
     in ''
       mkdir -p vendor/github.com/nlewo/nix2container/


### PR DESCRIPTION
The hash of the patch changed again. I saw #151 but I got a different hash value. After reading through https://github.com/NixOS/nixpkgs/issues/257446 I've found a proposal that seems to be stable enough to try.