### PR TITLE
Add cross-compilation support

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -16,6 +16,7 @@ import (
 
 var fromImageFilename string
 
+var imageArch string
 var created timeValue
 
 type timeValue time.Time
@@ -39,7 +40,7 @@ var imageCmd = &cobra.Command{
 	Short: "Generate an image.json file from a image configuration and layers",
 	Args:  cobra.MinimumNArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
-		err := image(args[0], args[1], fromImageFilename, args[2:], (time.Time)(created))
+		err := image(args[0], args[1], fromImageFilename, args[2:], imageArch, (time.Time)(created))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -107,7 +108,7 @@ func imageFromManifest(outputFilename, manifestFilename string, blobsFilename st
 	return nil
 }
 
-func image(outputFilename, imageConfigPath string, fromImageFilename string, layerPaths []string, created time.Time) error {
+func image(outputFilename, imageConfigPath string, fromImageFilename string, layerPaths []string, arch string, created time.Time) error {
 	var imageConfig v1.ImageConfig
 	var image types.Image
 
@@ -133,7 +134,7 @@ func image(outputFilename, imageConfigPath string, fromImageFilename string, lay
 		logrus.Infof("Using base image %s containing %d layers", fromImageFilename, len(fromImage.Layers))
 	}
 
-	image.Arch = runtime.GOARCH
+	image.Arch = arch
 
 	image.ImageConfig = imageConfig
 
@@ -167,6 +168,7 @@ func image(outputFilename, imageConfigPath string, fromImageFilename string, lay
 func init() {
 	rootCmd.AddCommand(imageCmd)
 	imageCmd.Flags().StringVarP(&fromImageFilename, "from-image", "", "", "A JSON file describing the base image")
+	imageCmd.Flags().StringVarP(&imageArch, "arch", "", runtime.GOARCH, "Target CPU architecture of the image")
 	imageCmd.Flags().Var(&created, "created", "Timestamp at which the image was created")
 	rootCmd.AddCommand(imageFromDirCmd)
 	rootCmd.AddCommand(imageFromManifestCmd)


### PR DESCRIPTION
Fixes #138 

This PR attempts to add cross-compilation support to `nix2container`. It's the same approach as taken in #139, but without moving derivations into separate files, so it should be much easier to review. 

**What was done:**
- Add and pass `--arch` argument to `nix2container image` command
- Wrap each derivation in `callPackage`
- Move derivation references to `builtInputs`/`nativeBuildInputs` (avoid `${foo}/bin/foo`)
- Explicitly pick the correct derivation variant (e.g. `pkgsBuildHost.<name>`) when `builtInputs`/`nativeBuildInputs` is not available 
- Expose derivations through `makeScopeWithSplicing'`

These changes as a whole make `nix2container` cross-compilation-aware when overlayed with a cross-compiling `pkgs` instance.

**Todo:**
- Some sort of basic cross-compilation test coverage. Ideally with a cross stdenv that's guaranteed to be cached in nixpkgs.

**Other thoughts:**
- I would still recommend moving all calPackage-based derivations into their own separate files in a followup MR. I think it will be easier to maintain as it won't be possible to accidentally reference derivations outside of callPackage scope.
