### PR TITLE
Add support for adding capabilities

### DIFF
--- a/cmd/layers.go
+++ b/cmd/layers.go
@@ -24,6 +24,7 @@ import (
 var ignore string
 var tarDirectory string
 var permsFilepath string
+var capsFilepath string
 var rewritesFilepath string
 var historyFilepath string
 var maxLayers int
@@ -57,6 +58,14 @@ var layersReproducibleCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+		var caps []types.CapabilityPath
+		if capsFilepath != "" {
+			caps, err = readCapsFile(capsFilepath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s", err)
+				os.Exit(1)
+			}
+		}
 		var rewrites []types.RewritePath
 		if rewritesFilepath != "" {
 			rewrites, err = readRewritesFile(rewritesFilepath)
@@ -74,7 +83,7 @@ var layersReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayers(storepaths, maxLayers, parents, rewrites, ignore, perms, history)
+		layers, err := nix.NewLayers(storepaths, maxLayers, parents, rewrites, ignore, perms, caps, history)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -116,6 +125,14 @@ var layersNonReproducibleCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+		var caps []types.CapabilityPath
+		if capsFilepath != "" {
+			caps, err = readCapsFile(capsFilepath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s", err)
+				os.Exit(1)
+			}
+		}
 		var rewrites []types.RewritePath
 		if rewritesFilepath != "" {
 			rewrites, err = readRewritesFile(rewritesFilepath)
@@ -133,7 +150,7 @@ var layersNonReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayersNonReproducible(storepaths, maxLayers, tarDirectory, parents, rewrites, ignore, perms, history)
+		layers, err := nix.NewLayersNonReproducible(storepaths, maxLayers, tarDirectory, parents, rewrites, ignore, perms, caps, history)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -178,6 +195,7 @@ func init() {
 
 	layersNonReproducibleCmd.Flags().StringVarP(&rewritesFilepath, "rewrites", "", "", "A JSON file containing a list of path rewrites. Each element of the list is a JSON object with the attributes path, regex and repl: for a given path, the regex is replaced by repl.")
 	layersNonReproducibleCmd.Flags().StringVarP(&permsFilepath, "perms", "", "", "A JSON file containing file permissions")
+	layersNonReproducibleCmd.Flags().StringVarP(&capsFilepath, "caps", "", "", "A JSON file containing file capabilities")
 	layersNonReproducibleCmd.Flags().StringVarP(&historyFilepath, "history", "", "", "A JSON file containing layer history")
 	layersNonReproducibleCmd.Flags().IntVarP(&maxLayers, "max-layers", "", 1, "The maximum number of layers")
 
@@ -185,6 +203,7 @@ func init() {
 	layersReproducibleCmd.Flags().StringVarP(&ignore, "ignore", "", "", "Ignore the path from the list of storepaths")
 	layersReproducibleCmd.Flags().StringVarP(&rewritesFilepath, "rewrites", "", "", "A JSON file containing path rewrites")
 	layersReproducibleCmd.Flags().StringVarP(&permsFilepath, "perms", "", "", "A JSON file containing file permissions")
+	layersNonReproducibleCmd.Flags().StringVarP(&capsFilepath, "caps", "", "", "A JSON file containing file capabilities")
 	layersReproducibleCmd.Flags().StringVarP(&historyFilepath, "history", "", "", "A JSON file containing layer history")
 	layersReproducibleCmd.Flags().IntVarP(&maxLayers, "max-layers", "", 1, "The maximum number of layers")
 

--- a/cmd/layers.go
+++ b/cmd/layers.go
@@ -203,7 +203,7 @@ func init() {
 	layersReproducibleCmd.Flags().StringVarP(&ignore, "ignore", "", "", "Ignore the path from the list of storepaths")
 	layersReproducibleCmd.Flags().StringVarP(&rewritesFilepath, "rewrites", "", "", "A JSON file containing path rewrites")
 	layersReproducibleCmd.Flags().StringVarP(&permsFilepath, "perms", "", "", "A JSON file containing file permissions")
-	layersNonReproducibleCmd.Flags().StringVarP(&capsFilepath, "caps", "", "", "A JSON file containing file capabilities")
+	layersReproducibleCmd.Flags().StringVarP(&capsFilepath, "caps", "", "", "A JSON file containing file capabilities")
 	layersReproducibleCmd.Flags().StringVarP(&historyFilepath, "history", "", "", "A JSON file containing layer history")
 	layersReproducibleCmd.Flags().IntVarP(&maxLayers, "max-layers", "", 1, "The maximum number of layers")
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -21,6 +21,18 @@ func readPermsFile(filename string) (permPaths []types.PermPath, err error) {
 	return
 }
 
+func readCapsFile(filename string) (capsPaths []types.CapabilityPath, err error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return capsPaths, err
+	}
+	err = json.Unmarshal(content, &capsPaths)
+	if err != nil {
+		return capsPaths, err
+	}
+	return
+}
+
 func readRewritesFile(filename string) (rewritePaths []types.RewritePath, err error) {
 	content, err := os.ReadFile(filename)
 	if err != nil {

--- a/default.nix
+++ b/default.nix
@@ -406,6 +406,15 @@ let
     # The mode is applied on a specific path. In this path subtree,
     # the mode is then applied on all files matching the regex.
     perms ? [],
+    # A list of capabilities  which are set when the tar layer is
+    # created: these capabilities are not written to the Nix store.
+    #
+    # Each element of this permission list is a dict such as
+    # { path = "a store path";
+    #   regex = ".*";
+    #   caps = ["CAP_NET_BIND_SERVICE"];
+    # }
+    capabilities ? [],
     # The maximun number of layer to create. This is based on the
     # store path "popularity" as described in
     # https://grahamc.com/blog/nix-and-layered-docker-images

--- a/default.nix
+++ b/default.nix
@@ -293,7 +293,7 @@ let
     rewritesFlag = "--rewrites ${rewritesFile}";
     permsFile = pkgs.writeText "perms.json" (l.toJSON perms);
     permsFlag = l.optionalString (perms != []) "--perms ${permsFile}";
-    capsFile = pkgs.writeText "caps.json" (l.toJSON perms);
+    capsFile = pkgs.writeText "caps.json" (l.toJSON capabilities);
     capsFlag = l.optionalString (capabilities != []) "--caps ${capsFile}";
     historyFile = pkgs.writeText "history.json" (l.toJSON metadata);
     historyFlag = l.optionalString (metadata != {}) "--history ${historyFile}";

--- a/default.nix
+++ b/default.nix
@@ -254,6 +254,15 @@ let
     # The mode is applied on a specific path. In this path subtree,
     # the mode is then applied on all files matching the regex.
     perms ? [],
+    # A list of capabilities  which are set when the tar layer is
+    # created: these capabilities are not written to the Nix store.
+    #
+    # Each element of this permission list is a dict such as
+    # { path = "a store path";
+    #   regex = ".*";
+    #   caps = ["CAP_NET_BIND_SERVICE"];
+    # }
+    capabilities ? [],
     # The maximun number of layer to create. This is based on the
     # store path "popularity" as described in
     # https://grahamc.com/blog/nix-and-layered-docker-images
@@ -284,6 +293,8 @@ let
     rewritesFlag = "--rewrites ${rewritesFile}";
     permsFile = pkgs.writeText "perms.json" (l.toJSON perms);
     permsFlag = l.optionalString (perms != []) "--perms ${permsFile}";
+    capsFile = pkgs.writeText "caps.json" (l.toJSON perms);
+    capsFlag = l.optionalString (capabilities != []) "--caps ${capsFile}";
     historyFile = pkgs.writeText "history.json" (l.toJSON metadata);
     historyFlag = l.optionalString (metadata != {}) "--history ${historyFile}";
     allDeps = deps ++ copyToRootList;
@@ -296,6 +307,7 @@ let
         --max-layers ${toString maxLayers} \
         ${rewritesFlag} \
         ${permsFlag} \
+        ${capsFlag} \
         ${historyFlag} \
         ${tarDirectory} \
         ${l.concatMapStringsSep " "  (l: l + "/layers.json") layers} \

--- a/examples/capabilities.nix
+++ b/examples/capabilities.nix
@@ -1,0 +1,58 @@
+{ pkgs, nix2container }:
+let
+    nginxPort = "80";
+    nginxConf = pkgs.writeText "nginx.conf" ''
+      user nobody nobody;
+      daemon off;
+      error_log /dev/stdout info;
+      pid /dev/null;
+      events {}
+      http {
+        access_log /dev/stdout;
+        server {
+          listen ${nginxPort};
+          index index.html;
+          location / {
+            root ${nginxWebRoot};
+          }
+        }
+      }
+    '';
+    nginxWebRoot = pkgs.writeTextDir "index.html" ''
+      <html><body><h1>Hello from NGINX</h1></body></html>
+    '';
+    nginxVar = pkgs.runCommand "nginx-var" {} ''
+      mkdir -p $out/var/log/nginx
+      mkdir -p $out/var/cache/nginx
+    '';
+in
+nix2container.buildImage {
+  name = "nginx";
+  
+  layers = [
+    (nix2container.buildLayer {
+        copyToRoot = [
+          pkgs.dockerTools.fakeNss
+          nginxVar
+        ];
+    })
+    (nix2container.buildLayer {
+      copyToRoot = [
+        pkgs.nginx
+      ];
+      capabilities = [
+        {
+          path = pkgs.nginx;
+          regex = "";
+          caps = [ "CAP_NET_BIND_SERVICE" ];
+        }
+      ];
+    })
+  ];
+  config = {
+    Cmd = [ "/bin/nginx" "-c" nginxConf ];
+    ExposedPorts = {
+      "${nginxPort}/tcp" = {};
+    };
+  };
+}

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -16,4 +16,5 @@
   ownership = pkgs.callPackage ./ownership.nix { inherit nix2container; };
   created = pkgs.callPackage ./created.nix { inherit nix2container; };
   metadata = pkgs.callPackage ./metadata.nix { inherit nix2container; };
+  capabilities = pkgs.callPackage ./capabilities.nix { inherit nix2container; };
 }

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func getPaths(storePaths []string, parents []types.Layer, rewrites []types.RewritePath, exclude string, permPaths []types.PermPath) types.Paths {
+func getPaths(storePaths []string, parents []types.Layer, rewrites []types.RewritePath, exclude string, permPaths []types.PermPath, capPaths []types.CapabilityPath) types.Paths {
 	var paths types.Paths
 	for _, p := range storePaths {
 		path := types.Path{
@@ -35,6 +35,19 @@ func getPaths(storePaths []string, parents []types.Layer, rewrites []types.Rewri
 		}
 		if perms != nil {
 			pathOptions.Perms = perms
+		}
+		var caps []types.Capability
+		for _, cap := range capPaths {
+			if p == cap.Path {
+				hasPathOptions = true
+				caps = append(caps, types.Capability{
+					Regex: cap.Regex,
+					Caps:  cap.Caps,
+				})
+			}
+		}
+		if caps != nil {
+			pathOptions.Capabilities = caps
 		}
 		for _, rewrite := range rewrites {
 			if p == rewrite.Path {
@@ -105,13 +118,13 @@ func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1
 	return layers, nil
 }
 
-func NewLayers(storePaths []string, maxLayers int, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
-	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
+func NewLayers(storePaths []string, maxLayers int, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, caps []types.CapabilityPath, history v1.History) ([]types.Layer, error) {
+	paths := getPaths(storePaths, parents, rewrites, exclude, perms, caps)
 	return newLayers(paths, "", maxLayers, history)
 }
 
-func NewLayersNonReproducible(storePaths []string, maxLayers int, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) (layers []types.Layer, err error) {
-	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
+func NewLayersNonReproducible(storePaths []string, maxLayers int, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, caps []types.CapabilityPath, history v1.History) (layers []types.Layer, err error) {
+	paths := getPaths(storePaths, parents, rewrites, exclude, perms, caps)
 	return newLayers(paths, tarDirectory, maxLayers, history)
 }
 

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -20,7 +20,7 @@ func TestPerms(t *testing.T) {
 			Mode:  "0641",
 		},
 	}
-	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", perms, v1.History{})
+	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", perms, []types.CapabilityPath{}, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -52,7 +52,7 @@ func TestNewLayers(t *testing.T) {
 	paths := []string{
 		"../data/layer1/file1",
 	}
-	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, []types.CapabilityPath{}, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -72,7 +72,7 @@ func TestNewLayers(t *testing.T) {
 	assert.Equal(t, expected, layer)
 
 	tmpDir := t.TempDir()
-	layer, err = NewLayersNonReproducible(paths, 1, tmpDir, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	layer, err = NewLayersNonReproducible(paths, 1, tmpDir, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, []types.CapabilityPath{}, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -154,7 +153,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 		// Handle capabilities if defined
 		if len(opts.Capabilities) > 0 {
 			logrus.Infof("We have capabilities")
-					// Initialize PAXRecords if nil
+			// Initialize PAXRecords if nil
 			if hdr.PAXRecords == nil {
 				hdr.PAXRecords = make(map[string]string)
 			}
@@ -192,7 +191,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 					}
 
 					capBytes := buf.Bytes()
-					hdr.PAXRecords["SCHILY.xattr.security.capability"] = hex.EncodeToString(capBytes)
+					hdr.PAXRecords["SCHILY.xattr.security.capability"] = string(capBytes)
 				}
 			}
 		}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -173,8 +173,10 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 
 					capBytes := buf.Bytes()
 
+					
 					// Convert to hex string
 					hexStr := hex.EncodeToString(capBytes)
+					fmt.Printf("capBytes: %v - %s\n", capBytes, hexStr)
 					hdr.PAXRecords["SCHILY.xattr.security.capability"] = hexStr
 				}
 			}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -150,7 +150,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 
 					// Set version 3 and no flags
 					// magic_etc = 0x20000000 + version
-					binary.LittleEndian.PutUint32(capBytes[0:], 0x20000003)
+					binary.LittleEndian.PutUint32(capBytes[0:], 0x03000000)
 
 					var effective, permitted, inheritable uint32
 

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -148,21 +148,18 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 		}
 
 
-		logrus.Infof("Check for capabilities")
-
 		// Handle capabilities if defined
 		if len(opts.Capabilities) > 0 {
-			logrus.Infof("We have capabilities")
 			// Initialize PAXRecords if nil
 			if hdr.PAXRecords == nil {
 				hdr.PAXRecords = make(map[string]string)
 			}
 
 			for _, cap := range opts.Capabilities {
-				logrus.Infof("path regex: %s", cap.Regex)
+				logrus.Infof("path regex: %s path: %s", cap.Regex, srcPath)
 				re := regexp.MustCompile(cap.Regex)
 				if re.Match([]byte(srcPath)) {
-					logrus.Infof("Regex matches!: %s", srcPath)
+					logrus.Infof("Regex matches!: %s path: %s", cap.Regex, srcPath)
 
 					data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
 

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -156,10 +156,10 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 			}
 
 			for _, cap := range opts.Capabilities {
-				fmt.Printf("path regex: %s\n", cap.Regex)
+				logrus.Infof("path regex: %s", cap.Regex)
 				re := regexp.MustCompile(cap.Regex)
 				if re.Match([]byte(srcPath)) {
-					fmt.Printf("Regex matches!: %s\n", srcPath)
+					logrus.Infof("Regex matches!: %s", srcPath)
 
 					data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
 

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -155,31 +155,26 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 				hdr.PAXRecords = make(map[string]string)
 			}
 
-			for _, cap := range opts.Capabilities {
-				re := regexp.MustCompile(cap.Regex)
-				if re.Match([]byte(srcPath)) {
-					data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
+			data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
 
-					data.Data[0].Permitted = uint32(10)
-					data.Data[0].Inheritable = uint32(10)
-					data.Data[1].Permitted = uint32(10 >> 32)
-					data.Data[1].Inheritable = uint32(10 >> 32)
-					data.Effective = uint32(10)
+			data.Data[0].Permitted = uint32(10)
+			data.Data[0].Inheritable = uint32(10)
+			data.Data[1].Permitted = uint32(10 >> 32)
+			data.Data[1].Inheritable = uint32(10 >> 32)
+			data.Effective = uint32(10)
 
-					buf := &bytes.Buffer{}
-					if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
-						return err
-					}
-
-					capBytes := buf.Bytes()
-
-					
-					// Convert to hex string
-					hexStr := hex.EncodeToString(capBytes)
-					fmt.Printf("capBytes: %v - %s\n", capBytes, hexStr)
-					hdr.PAXRecords["SCHILY.xattr.security.capability"] = hexStr
-				}
+			buf := &bytes.Buffer{}
+			if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
+				return err
 			}
+
+			capBytes := buf.Bytes()
+
+			
+			// Convert to hex string
+			hexStr := hex.EncodeToString(capBytes)
+			fmt.Printf("capBytes: %v - %s\n", capBytes, hexStr)
+			hdr.PAXRecords["SCHILY.xattr.security.capability"] = hexStr
 		}
 	}
 

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -148,8 +148,12 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 			}
 		}
 
+
+		logrus.Infof("Check for capabilities")
+
 		// Handle capabilities if defined
 		if len(opts.Capabilities) > 0 {
+			logrus.Infof("We have capabilities")
 					// Initialize PAXRecords if nil
 			if hdr.PAXRecords == nil {
 				hdr.PAXRecords = make(map[string]string)

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -156,7 +156,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 			}
 
 			for _, cap := range opts.Capabilities {
-				logrus.Infof("path regex: %s path: %s", cap.Regex, srcPath)
+				logrus.Infof("path regex: %s path: %s dst: %s", cap.Regex, srcPath, dstPath)
 				re := regexp.MustCompile(cap.Regex)
 				if re.Match([]byte(srcPath)) {
 					logrus.Infof("Regex matches!: %s path: %s", cap.Regex, srcPath)

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -156,8 +156,10 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 			}
 
 			for _, cap := range opts.Capabilities {
+				fmt.Printf("path regex: %s\n", cap.Regex)
 				re := regexp.MustCompile(cap.Regex)
-				if re.Match([]byte(hdr.Name)) {
+				if re.Match([]byte(srcPath)) {
+					fmt.Printf("Regex matches!: %s\n", srcPath)
 
 					data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
 

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -165,7 +165,7 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 					for _, capStr := range cap.Caps {
 						switch capStr {
 						case "CAP_NET_BIND_SERVICE":
-							bit := uint32(1 << 10) // CAP_NET_BIND_SERVICE is 10
+							bit := uint32(10) // CAP_NET_BIND_SERVICE is 10
 							permitted |= bit
 							inheritable |= bit
 							effective |= bit
@@ -175,6 +175,8 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 
 					data.Data[0].Permitted = permitted
 					data.Data[0].Inheritable = inheritable
+					data.Data[1].Permitted = uint32(10 >> 32)
+					data.Data[1].Inheritable = uint32(10 >> 32)
 					data.Effective = effective
 
 					buf := &bytes.Buffer{}

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -2,6 +2,7 @@ package nix
 
 import (
 	"archive/tar"
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -75,6 +76,26 @@ func createDirectory(tw *tar.Writer, path string) error {
 	return nil
 }
 
+// Version 3 capability format
+// struct vfs_cap_data {
+//     __le32 magic_etc;            /* magic, version and flags */
+//     struct {
+//         __le32 permitted;        /* permitted capabilities */
+//         __le32 inheritable;      /* inheritable capabilities */
+//     } data[2];                   /* realistically, one is enough */
+//     __le32 effective;            /* effective capabilities */
+// };
+type vfsNsCapData struct {
+	MagicEtc uint32
+	Data     [2]struct {
+		Permitted   uint32
+		Inheritable uint32
+	}
+	Effective uint32
+}
+
+const vfsCapRevision3 = 0x03000000
+
 func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, opts *types.PathOptions) error {
 	var link string
 	var err error
@@ -137,41 +158,20 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 			for _, cap := range opts.Capabilities {
 				re := regexp.MustCompile(cap.Regex)
 				if re.Match([]byte(srcPath)) {
-					// Version 3 capability format
-					// struct vfs_cap_data {
-					//     __le32 magic_etc;            /* magic, version and flags */
-					//     struct {
-					//         __le32 permitted;        /* permitted capabilities */
-					//         __le32 inheritable;      /* inheritable capabilities */
-					//     } data[1];
-					//     __le32 effective;            /* effective capabilities */
-					// };
-					capBytes := make([]byte, 20)  // 5 32-bit integers
+					data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}
 
-					// Set version 3 and no flags
-					// magic_etc = 0x20000000 + version
-					binary.LittleEndian.PutUint32(capBytes[0:], 0x03000000)
+					data.Data[0].Permitted = uint32(10)
+					data.Data[0].Inheritable = uint32(10)
+					data.Data[1].Permitted = uint32(10 >> 32)
+					data.Data[1].Inheritable = uint32(10 >> 32)
+					data.Effective = uint32(10)
 
-					var effective, permitted, inheritable uint32
-
-					// Process each capability
-					for _, capStr := range cap.Caps {
-							switch capStr {
-							case "CAP_NET_BIND_SERVICE":
-									bit := uint32(1 << 10)  // CAP_NET_BIND_SERVICE is 10
-									effective |= bit
-									permitted |= bit
-									inheritable |= bit
-							// Add more cases for other capabilities as needed
-							}
+					buf := &bytes.Buffer{}
+					if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
+						return err
 					}
 
-					// Write permitted and inheritable caps
-					binary.LittleEndian.PutUint32(capBytes[4:], permitted)
-					binary.LittleEndian.PutUint32(capBytes[8:], inheritable)
-					
-					// Write effective bitmask
-					binary.LittleEndian.PutUint32(capBytes[12:], effective)
+					capBytes := buf.Bytes()
 
 					// Convert to hex string
 					hexStr := hex.EncodeToString(capBytes)

--- a/types/types.go
+++ b/types/types.go
@@ -60,9 +60,15 @@ type PermPath struct {
 	Gname string `json:"gname"`
 }
 
+type Capability struct {
+	Regex string   `json:"regex"`
+	Caps  []string `json:"caps"`
+}
+
 type PathOptions struct {
 	Rewrite Rewrite `json:"rewrite,omitempty"`
 	Perms   []Perm  `json:"perms,omitempty"`
+	Capabilities []Capability `json:"capabilities,omitempty"`
 }
 
 type Path struct {

--- a/types/types.go
+++ b/types/types.go
@@ -65,6 +65,12 @@ type Capability struct {
 	Caps  []string `json:"caps"`
 }
 
+type CapabilityPath struct {
+	Path  string 	 `json:"path"`
+	Regex string   `json:"regex"`
+	Caps  []string `json:"caps"`
+}
+
 type PathOptions struct {
 	Rewrite Rewrite `json:"rewrite,omitempty"`
 	Perms   []Perm  `json:"perms,omitempty"`


### PR DESCRIPTION
This is very hacky, just wanted to push before I close for the day. 

I'm not a Go programmer at all so excuse the quality. I tried basing the changes on the `perms` feature which seems like it's quite similar in use.

This doesn't seem to work as expected as when it's untared it doesn't have the correct capabilities. But I do have a small Go program to test that the bytes seems to be generated correctly, so I assume it's a question of trying to figure out what format the string should be in.

```go
package main

import (
	"bytes"
	"encoding/binary"
	"fmt"
	"os"
	"syscall"
)

func main() {
    if len(os.Args) != 2 {
        fmt.Printf("Usage: %s <filepath>\n", os.Args[0])
        os.Exit(1)
    }
    filepath := os.Args[1]

    // Version 3 capability format
    // struct vfs_cap_data {
    //     __le32 magic_etc;            /* magic, version and flags */
    //     struct {
    //         __le32 permitted;        /* permitted capabilities */
    //         __le32 inheritable;      /* inheritable capabilities */
    //     } data[2];                   /* realistically, one is enough */
    //     __le32 effective;            /* effective capabilities */
    // };
		type vfsNsCapData struct {
			MagicEtc uint32
			Data     [2]struct {
				Permitted   uint32
				Inheritable uint32
			}
			Effective uint32
		}

		const vfsCapRevision3 = 0x03000000

		data := vfsNsCapData{MagicEtc: vfsCapRevision3 | uint32(0)}

		data.Data[0].Permitted = uint32(10)
		data.Data[0].Inheritable = uint32(10)
		data.Data[1].Permitted = uint32(10 >> 32)
		data.Data[1].Inheritable = uint32(10 >> 32)
		data.Effective = uint32(10)

		fmt.Printf("Failed to write buffer: %v\n", data)


    buf := &bytes.Buffer{}
		if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
			fmt.Printf("Failed to write buffer: %v\n", err)
			os.Exit(1)
		}

    capBytes := buf.Bytes()

		fmt.Printf("capBytes: %v\n", capBytes)

    // Set the extended attribute
    err := syscall.Setxattr(filepath, "security.capability", capBytes, 0)
    if err != nil {
        fmt.Printf("Failed to set capability: %v\n", err)
        os.Exit(1)
    }

    fmt.Printf("Successfully set CAP_NET_BIND_SERVICE capability on %s\n", filepath)
}
```