### PR TITLE
Remove flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1712920918,
@@ -35,23 +17,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,37 @@
 {
   description = "nix2container: build container image with Nix";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        nix2container = import ./. {
-          inherit pkgs system;
-        };
-        examples = import ./examples {
-          inherit pkgs;
-          inherit (nix2container) nix2container;
-        };
-        tests = import ./tests {
-          inherit pkgs examples;
-          inherit (nix2container) nix2container;
-        };
-      in
-        rec {
-          packages = {
-            inherit (nix2container) nix2container-bin skopeo-nix2container nix2container;
-            inherit examples tests;
+  outputs = { self, nixpkgs }:
+    let
+      defaultSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = nixpkgs.lib.genAttrs defaultSystems;
+    in {
+      packages = perSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nix2container = import ./. {
+            inherit pkgs system;
           };
-          defaultPackage = packages.nix2container-bin;
-        });
+          examples = import ./examples {
+            inherit pkgs;
+            inherit (nix2container) nix2container;
+          };
+          tests = import ./tests {
+            inherit pkgs examples;
+            inherit (nix2container) nix2container;
+          };
+        in {
+          inherit (nix2container) nix2container-bin skopeo-nix2container nix2container;
+          inherit examples tests;
+          default = nix2container.nix2container-bin;
+        }
+      );
+    };
 }


### PR DESCRIPTION
Manually handling `system` is similar to using `flake-utils`. So it's nice to have fewer inputs.
Moved `defaultPackage` to `packages.default` since the former is deprecated.