### PR TITLE
tests: demonstrate nested layers fail

### DIFF
--- a/examples/nested.nix
+++ b/examples/nested.nix
@@ -2,10 +2,14 @@
 nix2container.buildImage {
   name = "nested";
   config = {
-    entrypoint = ["${pkgs.hello}/bin/hello"];
+    entrypoint = ["/bin/bash" "-c" "${pkgs.hello}/bin/hello"];
   };
   layers = [(nix2container.buildLayer {
-    deps = [pkgs.bashInteractive];
+    copyToRoot = pkgs.buildEnv {
+      name = "root";
+      paths = [pkgs.bashInteractive];
+      pathsToLink = ["/bin"];
+    };
     layers = [
       (nix2container.buildLayer {
         deps = [pkgs.readline];


### PR DESCRIPTION
This PR fixes nothing, but shows how nested layers don't work as expected.

When a layer contains a sub-layer, sub-layers are excluded from the final image.

Just run this and check how it fails:

    nix run .#tests.nested
    
(If that fails because it can't exec, try merging [this commit](https://github.com/nlewo/nix2container/pull/129/commits/44cdfa847899b60cc77f5c6b09d1b529ba9edf2b)).

This failure I see locally:

    Actual output:
    /bin/bash: error while loading shared libraries: libreadline.so.8: cannot open shared object file: No such file or directory
    
    Expected pattern:
    Hello, world
    
    Error: test failed

@moduon MT-1075
