### PR TITLE
#89: added '--created now' option

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -19,22 +19,6 @@ var fromImageFilename string
 var imageArch string
 var created string
 
-type timeValue time.Time
-
-func (tv *timeValue) String() string {
-	return (*time.Time)(tv).Format(time.RFC3339)
-}
-
-func (tv *timeValue) Set(value string) error {
-	t, err := time.Parse(time.RFC3339, value)
-	*tv = timeValue(t)
-	return err
-}
-
-func (tv *timeValue) Type() string {
-	return "time"
-}
-
 var imageCmd = &cobra.Command{
 	Use:   "image OUTPUT-FILENAME CONFIG.JSON LAYERS-1.JSON LAYERS-2.JSON ...",
 	Short: "Generate an image.json file from a image configuration and layers",


### PR DESCRIPTION
Changed `--created` flag to a `StringVarP()` so that it can optionally be set to `now` to automatically get the current timestamp, instead of just a manually passing a timestamp. 

If the given timestamp is not parseable or "now", it still errors, just from later down the chain instead of by the cobra parser.

Closes #89 

(not a go programmer, lmk if you want it done differently)