### PR TITLE
buildImage: copy `copyToRoot` paths as symlinks if `initializeNixDatabase`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -372,6 +372,10 @@ let
     # paths added into the image. Note this is only useful to run nix
     # commands from the image, for instance to build an image used by
     # a CI to run Nix builds.
+    #
+    # To avoid path duplication across the image's store and root, this
+    # option converts paths in `copyToRoot` to symlinks to the image's
+    # store, fixing https://github.com/nlewo/nix2container/issues/192
     initializeNixDatabase ? false,
     # If initializeNixDatabase is set to true, the uid/gid of /nix can be
     # controlled using nixUid/nixGid.
@@ -404,10 +408,15 @@ let
           gid = nixGid;
         };
 
+      symlinks = pkgs.symlinkJoin {
+        name = "links";
+        paths = copyToRootList;
+      };
+
       customizationLayer = buildLayer {
         inherit maxLayers;
         perms = perms';
-        copyToRoot = copyToRootList ++ l.optional initializeNixDatabase nixDatabase;
+        copyToRoot = if initializeNixDatabase then [nixDatabase symlinks] else copyToRootList;
         deps = [configFile];
         ignore = configFile;
         layers = layers;


### PR DESCRIPTION
Fixes https://github.com/nlewo/nix2container/issues/192.

My initial thought was to use hardlinks, but these seem to basically be impossible to do in an OCI image.