### PR TITLE
Use size-cohort grouping for --max-layers instead of popularity singletons

### DIFF
--- a/closure/autolayer.go
+++ b/closure/autolayer.go
@@ -1,0 +1,214 @@
+// Package closure: autolayer.go is a Go port of the size-cohort layering
+// algorithm from nixpkgs' pkgs/build-support/docker/auto-layer.py (MIT
+// license; original by Lars Jellema, nixpkgs commit ff214e9d0e5e,
+// nixpkgs PR #355189). This
+// port is offered under nix2container's Apache-2.0 license; the algorithm
+// description in the comments below is adapted from the original under
+// MIT. See the nixpkgs file for the full rationale.
+//
+// The existing SortedPathsByPopularity + newLayers pairing puts the
+// (maxLayers-1) most-referenced store paths in singleton layers and dumps
+// everything else into one catch-all layer. For typical closures the
+// catch-all ends up holding the application-specific leaves (the roots of
+// the closure graph — the things that change most often) alongside most of
+// the bytes, so a one-path change re-uploads the bulk of the image.
+//
+// This algorithm instead picks the largest paths by narSize as "primaries",
+// one per iteration, and assigns every other path to the layer identified
+// by the set of primaries that (transitively) depend on it. Paths used by
+// exactly the same set of primaries land in the same layer; paths used by
+// nothing (closure roots) share one small layer. Iteration stops when
+// adding the next primary would exceed maxLayers.
+//
+// Determinism: the primary order is narSize descending with path as the
+// tiebreak; the layer-ID sets are content-addressed; the output layer
+// order is closureSize ascending with the sorted layer-ID as tiebreak. The
+// same closure graph always produces the same grouping, and adding one
+// small leaf path to the closure leaves every primary's layer assignment
+// unchanged (the new leaf lands in the roots layer).
+package closure
+
+import (
+	"sort"
+	"strings"
+)
+
+// LayeredPaths groups the closure into at most maxLayers layers. Each
+// returned slice is one layer's store paths, ordered so that a layer comes
+// after every layer it depends on. Paths are deterministically sorted
+// within each layer.
+func LayeredPaths(storepaths []Storepath, maxLayers int) [][]string {
+	if maxLayers < 1 {
+		maxLayers = 1
+	}
+
+	// Index by path; build forward (references) and reverse (users) adjacency.
+	type node struct {
+		size  int64
+		refs  []string // direct references (deduped, self-loop dropped)
+		users []string // direct referrers
+	}
+	nodes := make(map[string]*node, len(storepaths))
+	for _, sp := range storepaths {
+		n := &node{size: sp.NarSize}
+		seen := map[string]bool{sp.Path: true}
+		for _, r := range sp.References {
+			if !seen[r] {
+				seen[r] = true
+				n.refs = append(n.refs, r)
+			}
+		}
+		nodes[sp.Path] = n
+	}
+	for p, n := range nodes {
+		for _, r := range n.refs {
+			if rn, ok := nodes[r]; ok {
+				rn.users = append(rn.users, p)
+			}
+		}
+	}
+
+	// Transitive closure over an adjacency function.
+	walk := func(start string, adj func(string) []string) map[string]bool {
+		seen := map[string]bool{start: true}
+		stack := []string{start}
+		for len(stack) > 0 {
+			p := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, q := range adj(p) {
+				if !seen[q] {
+					seen[q] = true
+					stack = append(stack, q)
+				}
+			}
+		}
+		return seen
+	}
+
+	// Primary candidates, largest first; path as tiebreak for determinism.
+	bySize := make([]string, 0, len(nodes))
+	for p := range nodes {
+		bySize = append(bySize, p)
+	}
+	sort.Slice(bySize, func(i, j int) bool {
+		if nodes[bySize[i]].size != nodes[bySize[j]].size {
+			return nodes[bySize[i]].size > nodes[bySize[j]].size
+		}
+		return bySize[i] < bySize[j]
+	})
+
+	// layerOf[path] = set of primaries whose closure contains path (and which
+	// are not themselves in another chosen primary's closure).
+	layerOf := make(map[string]map[string]bool, len(nodes))
+	for p := range nodes {
+		layerOf[p] = map[string]bool{}
+	}
+
+	layerCount := func(split map[string]map[string]bool) int {
+		seen := map[string]bool{}
+		for _, s := range split {
+			seen[keyOf(s)] = true
+		}
+		return len(seen)
+	}
+
+	for _, primary := range bySize {
+		next := make(map[string]map[string]bool, len(layerOf))
+		for p, s := range layerOf {
+			ns := make(map[string]bool, len(s))
+			for k := range s {
+				ns[k] = true
+			}
+			next[p] = ns
+		}
+		next[primary] = map[string]bool{primary: true}
+		deps := walk(primary, func(p string) []string { return nodes[p].refs })
+		delete(deps, primary)
+		users := walk(primary, func(p string) []string { return nodes[p].users })
+		delete(users, primary)
+		for d := range deps {
+			// Drop any existing primary-user of d that is itself a user of
+			// the new primary (the new primary subsumes it for d's cohort).
+			for u := range users {
+				delete(next[d], u)
+			}
+			// If none of d's remaining primary-users is itself a dependency
+			// of the new primary, the new primary is a direct cohort member.
+			covered := false
+			for u := range next[d] {
+				if deps[u] {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				next[d][primary] = true
+			}
+		}
+		if layerCount(next) > maxLayers {
+			break
+		}
+		layerOf = next
+	}
+
+	// Materialize layers keyed by their primary-set.
+	type layer struct {
+		id          string
+		paths       []string
+		closureSize int64
+	}
+	byID := map[string]*layer{}
+	for p, s := range layerOf {
+		id := keyOf(s)
+		l, ok := byID[id]
+		if !ok {
+			l = &layer{id: id}
+			byID[id] = l
+		}
+		l.paths = append(l.paths, p)
+	}
+	for _, l := range byID {
+		// closureSize = sum of narSize over the layer's full dependency
+		// closure. A layer's closure strictly contains every layer it
+		// depends on, so ordering by closureSize is a valid topological
+		// order (matching auto-layer.py's "neat" ordering).
+		seen := map[string]bool{}
+		for _, p := range l.paths {
+			for d := range walk(p, func(q string) []string { return nodes[q].refs }) {
+				seen[d] = true
+			}
+		}
+		for d := range seen {
+			l.closureSize += nodes[d].size
+		}
+		sort.Strings(l.paths)
+	}
+
+	ordered := make([]*layer, 0, len(byID))
+	for _, l := range byID {
+		ordered = append(ordered, l)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].closureSize != ordered[j].closureSize {
+			return ordered[i].closureSize < ordered[j].closureSize
+		}
+		return ordered[i].id < ordered[j].id
+	})
+
+	out := make([][]string, len(ordered))
+	for i, l := range ordered {
+		out[i] = l.paths
+	}
+	return out
+}
+
+// keyOf canonicalizes a primary-set as a sorted, NUL-joined string so it
+// can be used as a map key. Store paths never contain NUL.
+func keyOf(s map[string]bool) string {
+	ks := make([]string, 0, len(s))
+	for k := range s {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return strings.Join(ks, "\x00")
+}

--- a/closure/autolayer_test.go
+++ b/closure/autolayer_test.go
@@ -1,0 +1,179 @@
+package closure
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Small hand-built closure: three independent "large" roots (P, Q, R)
+// sharing a common dependency chain C→B→A, plus a tiny leaf L that
+// nothing depends on (the closure root / perturbation stand-in).
+//
+//	P(100) ─┐
+//	Q( 90) ─┼─► C(10) ─► B(10) ─► A(10)
+//	R( 80) ─┘
+//	L(  1)
+//
+// With maxLayers=5 we expect: [A,B,C] (shared by {P,Q,R}), [P], [Q],
+// [R], [L] — the tiny leaf lands alone instead of in a catch-all with
+// P/Q/R's private bytes.
+func testGraph() []Storepath {
+	return []Storepath{
+		{Path: "A", NarSize: 10, References: []string{"A"}},
+		{Path: "B", NarSize: 10, References: []string{"B", "A"}},
+		{Path: "C", NarSize: 10, References: []string{"C", "B"}},
+		{Path: "P", NarSize: 100, References: []string{"P", "C"}},
+		{Path: "Q", NarSize: 90, References: []string{"Q", "C"}},
+		{Path: "R", NarSize: 80, References: []string{"R", "C"}},
+		{Path: "L", NarSize: 1, References: []string{"L"}},
+	}
+}
+
+func TestLayeredPathsDeterministic(t *testing.T) {
+	g := testGraph()
+	a := LayeredPaths(g, 5)
+	// Same closure, shuffled input order → identical output.
+	g2 := []Storepath{g[3], g[6], g[0], g[5], g[2], g[1], g[4]}
+	b := LayeredPaths(g2, 5)
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("non-deterministic: %v vs %v", a, b)
+	}
+	if len(a) > 5 {
+		t.Fatalf("exceeded maxLayers: got %d", len(a))
+	}
+	// L (the leaf) must be alone or with other roots only — never grouped
+	// with P/Q/R's bytes.
+	for _, layer := range a {
+		hasL, hasP := false, false
+		for _, p := range layer {
+			if p == "L" {
+				hasL = true
+			}
+			if p == "P" || p == "Q" || p == "R" {
+				hasP = true
+			}
+		}
+		if hasL && hasP {
+			t.Fatalf("leaf L grouped with a primary: %v", layer)
+		}
+	}
+}
+
+// Adding one tiny leaf must not perturb any existing layer's path set —
+// the load-bearing property for incremental pushes.
+func TestLayeredPathsMinimalDelta(t *testing.T) {
+	g := testGraph()
+	before := LayeredPaths(g, 5)
+	g2 := append(g, Storepath{Path: "L2", NarSize: 1, References: []string{"L2"}})
+	after := LayeredPaths(g2, 5)
+
+	// Every layer in 'before' that doesn't mention L must appear verbatim
+	// in 'after' (L2 lands in the roots layer alongside L).
+	index := map[string]bool{}
+	for _, l := range after {
+		index[key(l)] = true
+	}
+	for _, l := range before {
+		if contains(l, "L") {
+			continue // the roots layer gains L2; everything else is stable.
+		}
+		if !index[key(l)] {
+			t.Fatalf("adding a leaf perturbed an unrelated layer: %v", l)
+		}
+	}
+}
+
+func key(l []string) string {
+	s := ""
+	for _, p := range l {
+		s += p + ","
+	}
+	return s
+}
+
+func contains(l []string, p string) bool {
+	for _, x := range l {
+		if x == p {
+			return true
+		}
+	}
+	return false
+}
+
+func TestLayeredPathsMaxLayers1(t *testing.T) {
+	g := testGraph()
+	out := LayeredPaths(g, 1)
+	if len(out) != 1 {
+		t.Fatalf("maxLayers=1 → %d layers", len(out))
+	}
+	if len(out[0]) != len(g) {
+		t.Fatalf("maxLayers=1 layer has %d paths, want %d", len(out[0]), len(g))
+	}
+}
+
+func TestLayeredPathsFewerPathsThanLayers(t *testing.T) {
+	// 7 paths, maxLayers=100 → should use ≤7 layers and not panic.
+	out := LayeredPaths(testGraph(), 100)
+	if len(out) > 7 {
+		t.Fatalf("more layers (%d) than paths (7)", len(out))
+	}
+}
+
+func TestLayeredPathsEmpty(t *testing.T) {
+	out := LayeredPaths([]Storepath{}, 10)
+	if len(out) != 0 {
+		t.Fatalf("empty graph → %d layers", len(out))
+	}
+}
+
+// One giant path + many tiny leaves (the "few huge, many small" closure
+// shape). The giant path must get its own layer; the tiny leaves share
+// the roots layer, NOT the giant's.
+func TestLayeredPathsAsymmetric(t *testing.T) {
+	g := []Storepath{
+		{Path: "glibc", NarSize: 30, References: []string{"glibc"}},
+		{Path: "giant", NarSize: 10000, References: []string{"giant", "glibc"}},
+	}
+	for i := 0; i < 50; i++ {
+		p := string(rune('a'+i%26)) + string(rune('0'+i/26))
+		g = append(g, Storepath{Path: p, NarSize: 1, References: []string{p, "glibc"}})
+	}
+	out := LayeredPaths(g, 10)
+	if len(out) > 10 {
+		t.Fatalf("exceeded maxLayers: %d", len(out))
+	}
+	// giant must be alone (or with only its private deps, of which it has none).
+	for _, l := range out {
+		if contains(l, "giant") && len(l) != 1 {
+			t.Fatalf("giant not isolated: %v", l)
+		}
+	}
+	// glibc (the shared dep) must be isolated from the leaves — if a leaf
+	// changes, glibc's layer shouldn't re-upload.
+	for _, l := range out {
+		if contains(l, "glibc") {
+			for _, p := range l {
+				if p != "glibc" && p != "giant" {
+					t.Fatalf("glibc grouped with leaf %s: %v", p, l)
+				}
+			}
+		}
+	}
+	// The remaining tiny leaves (after the algorithm has spent the layer
+	// budget on the largest-first primaries) share the roots layer — no
+	// leaf ends up grouped with giant's bytes.
+	var leafBytes int64
+	for _, l := range out {
+		for _, p := range l {
+			if p != "giant" && p != "glibc" {
+				leafBytes++ // each leaf is size 1
+			}
+		}
+		if contains(l, "giant") && len(l) > 1 {
+			t.Fatalf("giant grouped with something: %v", l)
+		}
+	}
+	if leafBytes != 50 {
+		t.Fatalf("lost a path: leaf count %d", leafBytes)
+	}
+}

--- a/closure/file.go
+++ b/closure/file.go
@@ -8,6 +8,7 @@ import (
 type Storepath struct {
 	Path       string   `json:"path"`
 	References []string `json:"references"`
+	NarSize    int64    `json:"narSize"`
 }
 
 func ReadClosureGraphFile(filename string) (storepaths []Storepath, err error) {

--- a/cmd/layers.go
+++ b/cmd/layers.go
@@ -1,7 +1,7 @@
-// The generated structure is a list of layers. Currently, the list
-// always contains a single Layer, but in the future, we would like to
-// generate several layers with some algorithms, such as
-// https://grahamc.com/blog/nix-and-layered-docker-images
+// The generated structure is a list of layers. The closure is grouped
+// into up to --max-layers layers by closure.LayeredPaths (a size-cohort
+// algorithm in the spirit of
+// https://grahamc.com/blog/nix-and-layered-docker-images).
 
 package cmd
 
@@ -39,11 +39,7 @@ var layersReproducibleCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
 		}
-		storepaths, err := closure.SortedPathsByPopularity(closureGraph)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
-			os.Exit(1)
-		}
+		groups := closure.LayeredPaths(closureGraph, maxLayers)
 		parents, err := getLayersFromFiles(args[2:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
@@ -74,7 +70,7 @@ var layersReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayers(storepaths, maxLayers, parents, rewrites, ignore, perms, history)
+		layers, err := nix.NewLayers(groups, parents, rewrites, ignore, perms, history)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -98,11 +94,7 @@ var layersNonReproducibleCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
 		}
-		storepaths, err := closure.SortedPathsByPopularity(closureGraph)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
-			os.Exit(1)
-		}
+		groups := closure.LayeredPaths(closureGraph, maxLayers)
 		parents, err := getLayersFromFiles(args[2:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
@@ -133,7 +125,7 @@ var layersNonReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayersNonReproducible(storepaths, maxLayers, tarDirectory, parents, rewrites, ignore, perms, history)
+		layers, err := nix.NewLayersNonReproducible(groups, tarDirectory, parents, rewrites, ignore, perms, history)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -64,21 +64,21 @@ func getPaths(storePaths []string, parents []types.Layer, rewrites []types.Rewri
 // If tarDirectory is not an empty string, the tar layer is written to
 // the disk. This is useful for layer containing non reproducible
 // store paths.
-func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1.History) (layers []types.Layer, err error) {
-	offset := 0
-	for offset < len(paths) {
-		max := offset + 1
-		if offset == maxLayers-1 {
-			max = len(paths)
+//
+// groups is the layer assignment: each inner slice becomes one layer.
+// The caller (cmd/layers.go) computes it via closure.LayeredPaths.
+func newLayers(groups []types.Paths, tarDirectory string, history v1.History) (layers []types.Layer, err error) {
+	for _, layerPaths := range groups {
+		if len(layerPaths) == 0 {
+			continue
 		}
-		layerPaths := paths[offset:max]
 		layerPath := ""
 		var digest godigest.Digest
 		var size int64
 		if tarDirectory == "" {
 			digest, size, err = TarPathsSum(layerPaths)
 		} else {
-			layerPath, digest, size, err = TarPathsWrite(paths, tarDirectory)
+			layerPath, digest, size, err = TarPathsWrite(layerPaths, tarDirectory)
 		}
 		if err != nil {
 			return layers, err
@@ -99,20 +99,32 @@ func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1
 		}
 
 		layers = append(layers, layer)
-
-		offset = max
 	}
 	return layers, nil
 }
 
-func NewLayers(storePaths []string, maxLayers int, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
-	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
-	return newLayers(paths, "", maxLayers, history)
+// groupPaths applies the parent/rewrite/exclude/perm filtering to each
+// group and drops groups that end up empty (every path already present in
+// a parent layer, or all excluded).
+func groupPaths(groups [][]string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath) []types.Paths {
+	out := make([]types.Paths, 0, len(groups))
+	for _, g := range groups {
+		ps := getPaths(g, parents, rewrites, exclude, perms)
+		if len(ps) > 0 {
+			out = append(out, ps)
+		}
+	}
+	return out
 }
 
-func NewLayersNonReproducible(storePaths []string, maxLayers int, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) (layers []types.Layer, err error) {
-	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
-	return newLayers(paths, tarDirectory, maxLayers, history)
+// NewLayers turns layer groups into layers: each inner slice of groups
+// becomes one layer (after parent/exclude filtering).
+func NewLayers(groups [][]string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
+	return newLayers(groupPaths(groups, parents, rewrites, exclude, perms), "", history)
+}
+
+func NewLayersNonReproducible(groups [][]string, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) (layers []types.Layer, err error) {
+	return newLayers(groupPaths(groups, parents, rewrites, exclude, perms), tarDirectory, history)
 }
 
 func isPathInLayers(layers []types.Layer, path types.Path) bool {

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -20,7 +20,7 @@ func TestPerms(t *testing.T) {
 			Mode:  "0641",
 		},
 	}
-	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", perms, v1.History{})
+	layer, err := NewLayers([][]string{paths}, []types.Layer{}, []types.RewritePath{}, "", perms, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -52,7 +52,7 @@ func TestNewLayers(t *testing.T) {
 	paths := []string{
 		"../data/layer1/file1",
 	}
-	layer, err := NewLayers(paths, 1, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	layer, err := NewLayers([][]string{paths}, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -72,7 +72,7 @@ func TestNewLayers(t *testing.T) {
 	assert.Equal(t, expected, layer)
 
 	tmpDir := t.TempDir()
-	layer, err = NewLayersNonReproducible(paths, 1, tmpDir, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	layer, err = NewLayersNonReproducible([][]string{paths}, tmpDir, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
The current --max-layers grouping puts the (maxLayers-1) most-referenced paths in their own layers and dumps everything else into one catch-all layer. The problem is that the catch-all ends up with the least-referenced
paths, i.e. the closure roots — the stuff that changes most often — plus most of the image bytes. On a ~4GB / 125-layer test image against a local registry, touching a single file re-uploaded ~2.9GB. The catch-all layer alone was ~71% of the image.

This PR ports the size-cohort algorithm from nixpkgs' pkgs/build-support/docker/auto-layer.py (MIT, by Lars Jellema, nixpkgs commit ff214e9d0e5e, NixOS/nixpkgs#355189 — attribution is in the file header) to Go as closure.LayeredPaths, and wires it into both layers-from-*-storepaths commands. It picks the largest paths by narSize
as "primaries" one at a time and groups every other path by the set of primaries that transitively depend on it. Shared deps end up in shared layers, closure roots end up in one small layer, and it stops before exceeding maxLayers. Same one-file change on the test image: ~9MB re-uploaded.

The grouping is a pure function of the closure graph (deterministic ordering at every step), and adding a small leaf path doesn't move any existing layer — that's the property that keeps incremental pushes cheap, and it's what TestLayeredPathsMinimalDelta checks. Like the Python original, it assumes the graph is closed under references, which exportReferencesGraph guarantees.

A few other things that came along:

- closure.Storepath now reads narSize from the closure graph JSON (default.nix already emits it, it just wasn't deserialized)
- fixes a pre-existing bug in the --tar-directory path: TarPathsWrite got the full path list for every layer instead of that layer's paths, so every layer tar contained the whole image
- SortedPathsByPopularity is no longer used by cmd/. I left it in place to avoid breaking anyone importing it, but if you'd rather delete it (and drop the gonum dep with it) I can do that here

Refs #27, #31, #113 — this is basically the "largest closures should get their own layers first" idea from #27, and it addresses the volatility problem described in #31.

Heads up: I have a follow-up adding optional build-time compression that also touches nix.NewLayers' signature, so whichever lands second I'll rebase.

---

Disclaimer: I used LLM assistance (Claude) while preparing this port and PR; I've reviewed the code and the attribution above myself.
