### PR TITLE
Propagate layer sizes in from-image entries

### DIFF
--- a/nix/image.go
+++ b/nix/image.go
@@ -156,6 +156,7 @@ func NewImageFromDir(directory string) (image types.Image, err error) {
 		layer := types.Layer{
 			LayerPath: layerFilename,
 			Digest:    l.Digest.String(),
+			Size:      l.Size,
 			DiffIDs:   v1ImageConfig.RootFS.DiffIDs[i].String(),
 		}
 		switch l.MediaType {
@@ -220,6 +221,7 @@ func NewImageFromManifest(manifestFilename string, blobMapFilename string) (imag
 		layer := types.Layer{
 			LayerPath: layerFilename,
 			Digest:    l.Digest.String(),
+			Size:      l.Size,
 			DiffIDs:   v1ImageConfig.RootFS.DiffIDs[i].String(),
 		}
 		switch l.MediaType {

--- a/nix/image_test.go
+++ b/nix/image_test.go
@@ -20,6 +20,7 @@ func TestNewImageFromDir(t *testing.T) {
 		Layers: []types.Layer{
 			{
 				Digest:    "sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3",
+				Size:      2818413,
 				DiffIDs:   "sha256:8d3ac3489996423f53d6087c81180006263b79f206d3fdec9e66f0e27ceb8759",
 				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
 				LayerPath: "../data/image-directory/59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3",

--- a/nix/layer.go
+++ b/nix/layer.go
@@ -10,7 +10,7 @@ import (
 func LayerGetBlob(layer types.Layer) (reader io.ReadCloser, size int64, err error) {
 	if layer.LayerPath != "" {
 		reader, err = os.Open(layer.LayerPath)
-		return
+		return reader, layer.Size, err
 	}
 	if layer.Paths != nil {
 		reader = TarPaths(layer.Paths)


### PR DESCRIPTION
Both from-image entry points (`image-from-dir` and the manifest-based
flow) build their `types.Layer` literals without `Size`, even though the
manifest descriptor's `l.Size` is right there in scope — so every
from-image layer entry in image.json carries `"size": 0`. The `nix:`
transport copies `layer.Size` verbatim into the manifest it serves, so
pushed manifests declare zero-size layers. Registries accept that, but
anything that validates blob length against the descriptor rejects the
image — e.g. `cosign copy` fails with:

    layer sha256:b15b682e…: size mismatch: manifest says 0, blob is 80617984

This copies `l.Size` in both literals (NewImageFromDir and
NewImageFromManifest have the identical omission), updates the
TestNewImageFromDir golden to the fixture's real size (2818413, matching
data/image-directory/manifest.json) so the suite enforces it from now
on, and makes LayerGetBlob return the stored size for LayerPath-backed
blobs instead of the named-return zero — so the Go API agrees with the
image.json it serves. That last line also appears in #206 (which makes
LayerPath the mainline case); whichever lands second rebases trivially
and I'll take care of it.

Verified red/green: the updated golden fails on master with `Size:0` and
passes with the fix; driving `nix2container image-from-dir` on the test
fixture emits `"size": 0` before and `"size": 2818413` after, matching
the manifest descriptor.

Two design notes for review, both fine either way:

- The size is taken from the source manifest (the OCI descriptor
  authority), not measured from the local blob. Both call sites have the
  blob on disk, so measuring instead would make the invariant hold by
  construction even against a stale hand-maintained manifest in
  pullImageFromManifest (whose blob FODs verify digest only). Happy to
  switch to stat-based sizes if you prefer.
- image.json files generated by older binaries still carry size 0 and
  are merged verbatim by `--from-image` (dedup is digest-keyed), so
  cached/committed from-image JSONs should be regenerated after
  upgrading to actually get correct manifests.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change
and PR; I've reviewed the code and tested it myself.
