### PR TITLE
types: marshal nil Layers as an empty array

### DIFF
--- a/types/marshal_test.go
+++ b/types/marshal_test.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A zero-value Image (a config-only image: no base image and no layer
+// entries) must marshal `"layers": []`, not `"layers": null`.
+func TestImageMarshalNilLayersAsEmpty(t *testing.T) {
+	var img Image
+	b, err := json.Marshal(img)
+	require.NoError(t, err)
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &fields))
+	assert.JSONEq(t, `[]`, string(fields["layers"]))
+}
+
+// Round-trip: normalization must not disturb populated layers.
+func TestImageMarshalRoundTrip(t *testing.T) {
+	img := Image{
+		Version: ImageVersion,
+		Layers:  []Layer{{Digest: "sha256:abc", DiffIDs: "sha256:def"}},
+	}
+	b, err := json.Marshal(img)
+	require.NoError(t, err)
+	var back Image
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, img.Layers, back.Layers)
+}

--- a/types/types.go
+++ b/types/types.go
@@ -22,6 +22,20 @@ type Image struct {
 	Created     *time.Time     `json:"created"`
 }
 
+// MarshalJSON normalizes nil Layers to an empty slice so consumers of
+// image.json never see `"layers": null`: a reader that indexes or
+// iterates the layers (e.g. `jq '.layers[]'`, or a Python script doing
+// `json["layers"]`) then works without a null guard. A nil Layers
+// slice is reachable for a config-only image (no base image and no
+// layer entries).
+func (i Image) MarshalJSON() ([]byte, error) {
+	type imageAlias Image // strip the method set to avoid recursion
+	if i.Layers == nil {
+		i.Layers = []Layer{}
+	}
+	return json.Marshal(imageAlias(i))
+}
+
 type Rewrite struct {
 	Regex string `json:"regex"`
 	Repl  string `json:"repl"`


### PR DESCRIPTION
A config-only image — no base image, no layer entries — marshals
`"layers": null` today:

    $ nix2container image out.json config.json empty-layers.json
    $ jq '.layers[]' out.json
    jq: error: Cannot iterate over null

Readers that index or iterate the layers (`jq '.layers[]'`, a Python
script doing `json["layers"]`) each need a null guard that's easy to
forget. This normalizes nil Layers to `[]` in `Image.MarshalJSON` (alias
type to avoid recursion, value receiver so callers' structs are
untouched). The `layers` key has no omitempty and was always emitted, so
only the value changes — schema and key set stay identical. Go consumers
are unaffected: everything in-repo unmarshals into `types.Image` and
uses range/len/append, which treat nil and `[]` the same.

Tests cover the config-only case and a populated round-trip.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change
and PR; I've reviewed the code and tested it myself.
