### PR TITLE
perms: add orMode to OR permission bits into the existing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Function arguments are:
     The mode is applied on a specific path. In this path subtree,
     the mode is then applied on all files matching the regex.
 
+    `mode` sets the mode, and `orMode` adds bits to it. For instance,
+    `orMode = "0200";` makes the files writable by their owner and
+    keeps their execute bits. With both, `mode` comes first:
+    `{ mode = "0444"; orMode = "0200"; }` gives `0644`. The entries
+    are applied in list order.
+
 - **`initializeNixDatabase`** (defaults to `false`): to initialize the
     Nix database with all store paths added into the image. Note this
     is only useful to run nix commands from the image, for instance to
@@ -258,6 +264,12 @@ Function arguments are:
     ```
     The mode is applied on a specific path. In this path subtree,
     the mode is then applied on all files matching the regex.
+
+    `mode` sets the mode, and `orMode` adds bits to it. For instance,
+    `orMode = "0200";` makes the files writable by their owner and
+    keeps their execute bits. With both, `mode` comes first:
+    `{ mode = "0444"; orMode = "0200"; }` gives `0644`. The entries
+    are applied in list order.
 
 - **`layers`** (defaults to `[]`): a list of layers built with the
     `buildLayer` function: if a store path in deps or contents belongs

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -24,12 +24,13 @@ func getPaths(storePaths []string, parents []types.Layer, rewrites []types.Rewri
 			if p == perm.Path {
 				hasPathOptions = true
 				perms = append(perms, types.Perm{
-					Regex: perm.Regex,
-					Mode:  perm.Mode,
-					Uid:   perm.Uid,
-					Gid:   perm.Gid,
-					Uname: perm.Uname,
-					Gname: perm.Gname,
+					Regex:  perm.Regex,
+					Mode:   perm.Mode,
+					OrMode: perm.OrMode,
+					Uid:    perm.Uid,
+					Gid:    perm.Gid,
+					Uname:  perm.Uname,
+					Gname:  perm.Gname,
 				})
 			}
 		}

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"archive/tar"
 	"testing"
 
 	"github.com/nlewo/nix2container/types"
@@ -91,4 +92,31 @@ func TestNewLayers(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, layer)
+}
+
+// OrMode must OR bits into the mode set by Mode: {Mode:"0444",
+// OrMode:"0311"} yields 0755 on a regular file.
+func TestPermsOrMode(t *testing.T) {
+	paths := []string{"../data/layer1/file1"}
+	perms := []types.PermPath{
+		{Path: "../data/layer1/file1", Regex: ".*", Mode: "0444", OrMode: "0311"},
+	}
+	layers, err := NewLayers(paths, 1, nil, nil, "", perms, v1.History{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := TarPaths(layers[0].Paths)
+	defer r.Close() // nolint: errcheck
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			break
+		}
+		if hdr.Name == "../data/layer1/file1" && hdr.Typeflag == tar.TypeReg {
+			assert.Equal(t, int64(0o755), hdr.Mode&0o777)
+			return
+		}
+	}
+	t.Fatal("file1 not found in layer tar")
 }

--- a/nix/tar.go
+++ b/nix/tar.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/nlewo/nix2container/types"
@@ -121,6 +122,21 @@ func appendFileToTar(tw *tar.Writer, srcPath, dstPath string, info os.FileInfo, 
 					if err != nil {
 						return err
 					}
+				}
+				if perms.OrMode != "" {
+					// fmt.Sscanf %o accepts garbage silently ("03x1"→3,
+					// "0o311"→0, "-0200"→-128, and a negative mode makes
+					// archive/tar silently switch the header to GNU
+					// base-256 encoding); ParseUint base 8 rejects all of
+					// it, and bitSize 12 bounds the value to the
+					// permission bits (0o7777). The value is the plain
+					// octal digits ("0200", matching Mode's convention
+					// above), no 0o prefix.
+					or, err := strconv.ParseUint(perms.OrMode, 8, 12)
+					if err != nil {
+						return fmt.Errorf("invalid orMode %q (want octal permission bits like \"0200\"): %w", perms.OrMode, err)
+					}
+					hdr.Mode |= int64(or)
 				}
 			}
 		}

--- a/nix/tar_test.go
+++ b/nix/tar_test.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"archive/tar"
 	"testing"
 
 	"github.com/nlewo/nix2container/types"
@@ -40,5 +41,29 @@ func TestRemoveNixCaseHackSuffix(t *testing.T) {
 	expected = "filename~nix~"
 	if ret != expected {
 		t.Errorf("%s should be %s", ret, expected)
+	}
+}
+
+// Invalid orMode values must fail loudly at tar time, not be silently
+// misparsed: Sscanf-style laxity here corrupts header modes (a negative
+// mode even flips archive/tar to GNU base-256 encoding).
+func TestTarPermsOrModeInvalid(t *testing.T) {
+	for _, orMode := range []string{"0o311", "-0200", "40755", "8"} {
+		t.Run(orMode, func(t *testing.T) {
+			paths := types.Paths{{
+				Path: "../data/layer1/file1",
+				Options: &types.PathOptions{
+					Perms: []types.Perm{{Regex: ".*", OrMode: orMode}},
+				},
+			}}
+			r := TarPaths(paths)
+			defer r.Close() // nolint: errcheck
+			tr := tar.NewReader(r)
+			var err error
+			for err == nil {
+				_, err = tr.Next()
+			}
+			assert.ErrorContains(t, err, "invalid orMode")
+		})
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -42,22 +42,30 @@ type RewritePath struct {
 type Perm struct {
 	Regex string `json:"regex"`
 	// Octal representation of file permissions
-	Mode  string `json:"mode"`
-	Uid   int    `json:"uid"`
-	Gid   int    `json:"gid"`
-	Uname string `json:"uname"`
-	Gname string `json:"gname"`
+	Mode string `json:"mode"`
+	// Octal permission bits to OR into the existing mode (e.g. "0200"
+	// to add u+w). Applied after Mode, so {Mode:"0444", OrMode:"0200"}
+	// yields 0644. Lets a single perms entry express "make writable"
+	// over a tree whose files are a mix of 0444/0555 (nix-store
+	// canonicalization) without flattening the execute bit.
+	OrMode string `json:"orMode,omitempty"`
+	Uid    int    `json:"uid"`
+	Gid    int    `json:"gid"`
+	Uname  string `json:"uname"`
+	Gname  string `json:"gname"`
 }
 
 type PermPath struct {
 	Path  string `json:"path"`
 	Regex string `json:"regex"`
 	// Octal representation of file permissions
-	Mode  string `json:"mode"`
-	Uid   int    `json:"uid"`
-	Gid   int    `json:"gid"`
-	Uname string `json:"uname"`
-	Gname string `json:"gname"`
+	Mode string `json:"mode"`
+	// See Perm.OrMode.
+	OrMode string `json:"orMode,omitempty"`
+	Uid    int    `json:"uid"`
+	Gid    int    `json:"gid"`
+	Uname  string `json:"uname"`
+	Gname  string `json:"gname"`
 }
 
 type PathOptions struct {


### PR DESCRIPTION
This adds `orMode` to the `perms` entries. `mode` sets the mode, and `orMode` adds bits to it.

## Why

A store tree has files with mode `0444` and files with mode `0555`. To make it writable, `mode = "0644"` removes the execute bits, and `mode = "0755"` adds them to every file. `orMode = "0200"` adds the write bit and keeps the rest:

```nix
perms = [ { path = drv; regex = ".*"; orMode = "0200"; } ];
```

## Behaviour

- With both, `mode` comes first: `{ mode = "0444"; orMode = "0200"; }` gives `0644`.
- The entries are applied in list order.
- `orMode` takes octal permission bits only, up to `7777`. Anything else is an error. A value out of that range would change how archive/tar encodes the header, without an error.
- `mode` does not change.

## Testing

- `TestPermsOrMode` checks `mode` and `orMode` together, through `NewLayers`.
- `TestTarPermsOrModeInvalid` checks that `0o311`, `-0200`, `40755` and `8` are rejected.
- The README documents `orMode` in both `perms` sections.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change and PR; I've reviewed the code and tested it myself.
