### PR TITLE
Add includeStorePaths option to buildLayer and buildImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Function arguments are:
     image of this image; use `pullImage` or `pullImageFromManifest` to
     supply this.
 
+- **`includeStorePaths`** (defaults to `true`): see
+    `buildLayer.includeStorePaths`. It applies to the image layers and
+    not to layers added with the `buildImage.layers` attribute.
+
 - **`maxLayers`** (defaults to `1`): the maximum number of layers to
     create. This is based on the store path "popularity" as described
     in this [blog
@@ -237,6 +241,14 @@ Function arguments are:
     is stored in the store path. This is useful when the layer
     dependencies are not bit reproducible: it allows to have the layer
     tarball and its hash in the same store path.
+
+- **`includeStorePaths`** (defaults to `true`): when `false`, the
+    layer holds the paths listed in `deps` and `copyToRoot`, but not
+    their runtime closure. The listed paths keep their store paths, so
+    their references must be present at run time, for instance through
+    a `/nix/store` mounted into the container. Those references are not
+    pushed with the image. dockerTools' `streamLayeredImage` has an
+    option with the same name, but it does not ship the store paths.
 
 - **`maxLayers`** (defaults to `1`): the maximum number of layers to
     create. This is based on the store path "popularity" as described

--- a/default.nix
+++ b/default.nix
@@ -237,6 +237,10 @@ let
     contents ? null,
     # Author, comment, created_by
     metadata ? { created_by = "nix2container"; },
+    # When false, the layer holds the paths of deps and copyToRoot but
+    # not their runtime closure. The references must be present at run
+    # time, for instance through a mounted /nix/store. See the README.
+    includeStorePaths ? true,
   }: let
     subcommand = if reproducible
       then "layers-from-reproducible-storepaths"
@@ -269,7 +273,7 @@ let
       set -x
       ${nix2container-bin}/bin/nix2container ${subcommand} \
         $out/layers.json \
-        ${closureGraph allDeps ignore} \
+        ${(if includeStorePaths then closureGraph else prunedClosureGraph) allDeps ignore} \
         --max-layers ${toString maxLayers} \
         ${rewritesFlag} \
         ${permsFlag} \
@@ -321,6 +325,41 @@ let
     } ''
       filter='select(.path | inside("${toString ignore}") | not)'
       jq ".graph | map($filter | .references |= sort) | sort_by(.path)" .attrs.json > $out
+    '';
+
+  # Like closureGraph, but keep only the explicitly-listed paths: every
+  # other closure entry is dropped and the kept entries' references are
+  # emptied. Layers built from this graph contain just the listed trees
+  # and none of their runtime closure — buildLayer/buildImage's
+  # `includeStorePaths = false`. Emptying references keeps the graph
+  # closed by construction, which the layer-grouping code relies on.
+  # exportReferencesGraph is still used (not a hand-built graph) so the
+  # kept entries carry the same narHash/narSize fields, in the same
+  # serialization, as the unpruned graph.
+  # Normalize a paths-list element to the store path root as
+  # exportReferencesGraph reports it: "${p}" imports path literals into
+  # the store (plain toString would keep the eval-time source path) and
+  # coerces derivations to their outPath; the match truncates store
+  # subpaths ("${pkg}/share/foo") to the store-path root.
+  storePathRoot = p:
+    let
+      s = "${p}";
+      m = l.match "(${builtins.storeDir}/[^/]+)(/.*)?" s;
+    in if m == null then s else l.head m;
+
+  prunedClosureGraph = paths: ignore:
+    pkgs.runCommand "closure-graph-pruned.json" {
+      __structuredAttrs = true;
+      exportReferencesGraph.graph = paths;
+      keepPaths = map storePathRoot paths;
+      nativeBuildInputs = [ pkgs.jq ];
+      outputChecks.out.disallowedReferences = l.toList (l.defaultTo [] ignore);
+    } ''
+      filter='select(.path | inside("${toString ignore}") | not)'
+      jq ".keepPaths as \$keep | .graph
+          | map(select(.path | IN(\$keep[])))
+          | map($filter | .references = [])
+          | sort_by(.path)" .attrs.json > $out
     '';
 
   buildImage = {
@@ -375,7 +414,17 @@ let
     # Deprecated: will be removed
     contents ? null,
     meta ? {},
+    # See buildLayer.includeStorePaths. Applies to the image's own
+    # layer (copyToRoot and its closure); explicit `layers` entries
+    # carry their own flag.
+    includeStorePaths ? true,
   }:
+    assert l.assertMsg (includeStorePaths || !initializeNixDatabase) ''
+      nix2container.buildImage: initializeNixDatabase = true with
+      includeStorePaths = false would register store paths the image
+      does not contain. Drop one of the two flags, or register the
+      runtime store's closure from the copyToRoot tree instead.
+    '';
     let
       configFile = pkgs.writeText "config.json" (l.toJSON config);
       copyToRootList = l.toList (l.defaultTo [] (l.defaultTo contents copyToRoot));
@@ -398,7 +447,7 @@ let
         };
 
       customizationLayer = buildLayer {
-        inherit maxLayers;
+        inherit maxLayers includeStorePaths;
         perms = perms';
         copyToRoot = copyToRootList ++ l.optional initializeNixDatabase nixDatabase;
         deps = [configFile];


### PR DESCRIPTION
This adds `includeStorePaths` to `buildLayer` and `buildImage`, `true` by default. With `false`, the layer holds the paths listed in `deps` and `copyToRoot`, but not their runtime closure.

## Why

Some containers get `/nix/store` at run time, from a volume or from a shared read-only store. For them, the closure in the layers only duplicates what the mount provides.

```nix
# the layer holds hello, and glibc comes from the store mount
buildLayer { deps = [ hello ]; includeStorePaths = false; }
```

The listed paths keep their store paths, so their references must be present at run time. dockerTools' `streamLayeredImage` has an option with the same name, but it does not ship the store paths.

## What changes

- `prunedClosureGraph` is `closureGraph` with only the listed paths, and with their references removed. It still uses `exportReferencesGraph`, so the entries have the same fields as before.
- A listed element becomes the store path that the graph reports:
  - A derivation becomes its `outPath`.
  - A path literal is imported into the store. Without that, the layer would be empty.
  - A subpath such as `"${hello}/bin"` becomes the store path of `hello`.
- `initializeNixDatabase = true` with `includeStorePaths = false` fails at eval time. The database would list paths that the image does not hold.
- The README documents the option under `buildLayer`, and `buildImage` points to it.

## Testing

- With the default, the layer derivation is the same as on master. The `drvPath` is equal.
- `buildLayer { deps = [ hello ]; }` holds hello and its closure. With `includeStorePaths = false`, and with `deps = [ "${hello}/bin" ]`, the layer holds only hello.
- The assert fires for `initializeNixDatabase = true`.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change and PR; I've reviewed the code and tested it myself.
