### PR TITLE
fix: concurrent access of the initialized nix database

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -305,6 +305,14 @@ let
       mkdir -p $out/nix/var/nix/db/
       sqlite3 $out/nix/var/nix/db/db.sqlite '.read db.dump'
 
+      # The dump doesn't carry the schema version marker. Without it Nix takes the store for a
+      # new one, and concurrent processes race to reinitialize it.
+      cp $PWD/nix/var/nix/db/schema $out/nix/var/nix/db/schema
+
+      # sqlite3 leaves the DB in `delete` mode, while Nix switches to WAL on open. That switch
+      # takes an exclusive lock, so concurrent openers fail with "database is busy".
+      sqlite3 $out/nix/var/nix/db/db.sqlite 'pragma journal_mode = wal' > /dev/null
+
       mkdir -p $out/nix/var/nix/gcroots/docker/
       ln -s $(jq -r '.[].path' ${closureGraphJson}) $out/nix/var/nix/gcroots/docker/
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -94,6 +94,48 @@ let
       command = "nix-store -qR ${pkgs.hello}";
       pattern = "${pkgs.hello}";
     };
+    # The schema marker and WAL mode are what let several processes open the store at once.
+    # Checked on the image: racing processes reproduce the bug, but only sometimes.
+    nixDatabaseIsUsableConcurrently = pkgs.runCommand "test-script" { buildInputs = [pkgs.jq pkgs.gnutar pkgs.sqlite]; } ''
+      set -e
+      ${examples.nix.copyTo}/bin/copy-to dir://$PWD/image
+      cd $PWD/image
+
+      # List to files first: with `pipefail`, a `grep -q` that matches kills `tar` with
+      # SIGPIPE and the pipeline reports failure.
+      for layer in $(jq -r '.layers[].digest' manifest.json | cut -d":" -f2); do
+        tar -tf "$layer" > "entries-$layer"
+      done
+
+      set -- $(grep -lE '(^|/)nix/var/nix/db/db\.sqlite$' entries-* || true)
+      if [ $# -eq 0 ]; then
+        echo "Error: no layer holds the Nix database"
+        exit 1
+      fi
+      entries=$1
+      dbLayer=''${entries#entries-}
+
+      echo "Checking the schema version marker is shipped..."
+      if ! grep -E '(^|/)nix/var/nix/db/schema$' "$entries" > /dev/null; then
+        echo "Error: the image ships no nix/var/nix/db/schema"
+        exit 1
+      fi
+
+      echo "Checking the database is in WAL mode..."
+      dbName=$(awk '/(^|\/)nix\/var\/nix\/db\/db\.sqlite$/ { print; exit }' "$entries")
+      tar -xOf "$dbLayer" "$dbName" > db.sqlite
+      journalMode=$(sqlite3 db.sqlite 'PRAGMA journal_mode;')
+      if [ "$journalMode" != "wal" ]; then
+        echo "Error: expected the database in WAL mode, got $journalMode"
+        exit 1
+      fi
+
+      echo Test passed
+      # TODO: actually this test doesn't need to be run
+      mkdir -p $out/bin
+      echo echo Test passed > $out/bin/test-script
+      chmod a+x $out/bin/test-script
+    '';
     # The /nix have to be explicitly present in the archive with 755 perms
     nonRegressionIssue12 = pkgs.runCommand "test-script" { buildInputs = [pkgs.jq pkgs.gnutar]; } ''
       set -e


### PR DESCRIPTION
When making some experiments with `nix2container`-based images, I noticed a lot of:
- `SQLite database '/nix/var/nix/db/db.sqlite' is busy`
- `"/nix/var/nix/db/schema" is corrupt`

After some LLM-assisted research, the bug turned out to be how the DB was initialized by `makeNixDatabase`.
- It misses `nix/var/nix/db/schema`, so every access to it by Nix will have `LocalStore::getSchema` returning `0`.
    Nix will thus think that it's an empty DB. If used by multiple Nix processes, they race to initialize the DB.
- It was creating the DB in `delete` mode, whereas Nix sets `journal_mode = wal` when it opens a DB.
    Switching the journal mode needs a lock, which doesn't play well with multiple workers.

For context, I noticed those symptoms as I'm playing with [nix-fast-build](https://github.com/Mic92/nix-fast-build), which uses [nix-eval-jobs](https://github.com/NixOS/nix-eval-jobs) under the hood.

I also got the LLM to write a test. I'd be happy to nuke it if you don't want to have it.
