### PR TITLE
fix: write only the layer's own paths to each layer tar

### DIFF
--- a/nix/layers.go
+++ b/nix/layers.go
@@ -78,7 +78,7 @@ func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1
 		if tarDirectory == "" {
 			digest, size, err = TarPathsSum(layerPaths)
 		} else {
-			layerPath, digest, size, err = TarPathsWrite(paths, tarDirectory)
+			layerPath, digest, size, err = TarPathsWrite(layerPaths, tarDirectory)
 		}
 		if err != nil {
 			return layers, err

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -92,3 +92,25 @@ func TestNewLayers(t *testing.T) {
 	}
 	assert.Equal(t, expected, layer)
 }
+
+// Each layer tar written to the tar directory must hold that layer's
+// paths only, so it must match the digest of the reproducible layer.
+func TestNewLayersNonReproducibleWritesEachLayer(t *testing.T) {
+	paths := []string{
+		"../data/layer1/file1",
+		"../data/tar-directory/file1",
+	}
+	reproducible, err := NewLayers(paths, 2, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	written, err := NewLayersNonReproducible(paths, 2, t.TempDir(), []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	assert.Len(t, written, 2)
+	for i := range written {
+		assert.Len(t, written[i].Paths, 1)
+		assert.Equal(t, reproducible[i].Digest, written[i].Digest)
+	}
+}


### PR DESCRIPTION
`newLayers` passes the whole path list to `TarPathsWrite`, so with `--tar-directory` (`buildLayer` with `reproducible = false`) every layer tar contains the paths of all the layers. Only the `Paths` field of each layer is right. The digest, the size and the tar file describe the whole set.

This is a one-line fix: pass the layer's own paths. The new test builds the same two layers with `NewLayers` and with `NewLayersNonReproducible`, and checks that each written tar has the digest of the matching reproducible layer. Without the fix, both written layers get the same digest.

I mentioned this bug in #204. I am closing that PR, so the fix comes on its own here.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change and PR; I've reviewed the code and tested it myself.
