### PR TITLE
feat: buildLayer layersFile, a layer split computed elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ Function arguments are:
     this is applied on the image layers and not on layers added with
     the `buildLayer.layers` attribute.
 
+- **`layersFile`** (defaults to `null`): a JSON file with the layer
+    split to use instead of `maxLayers`: a list of store path lists,
+    one list per layer, in order. Every path of the layer closure (the
+    closure of `deps` and `copyToRoot`, without `ignore`) must appear
+    in exactly one list, and no other path may appear. This lets the
+    split come from another tool, for instance the `store_layers` of
+    the `conf.json` that nixpkgs' `streamLayeredImage` writes.
+
 - **`perms`** (defaults to `[]`): a list of file permisssions which are
     set when the tar layer is created: these permissions are not
     written to the Nix store.

--- a/closure/splitfile.go
+++ b/closure/splitfile.go
@@ -1,0 +1,48 @@
+package closure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// SplitFromFile reads a layer split, a JSON list of store path lists in
+// layer order, and checks it against the closure graph: every path of
+// the graph must appear exactly once, and no other path may appear.
+// The split can come from another tool, for instance the store_layers
+// that nixpkgs' streamLayeredImage computes for the same closure.
+func SplitFromFile(storepaths []Storepath, filename string) ([][]string, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var split [][]string
+	if err := json.Unmarshal(data, &split); err != nil {
+		return nil, fmt.Errorf("%s: %w", filename, err)
+	}
+	want := make(map[string]bool, len(storepaths))
+	for _, sp := range storepaths {
+		want[sp.Path] = true
+	}
+	seen := make(map[string]bool, len(storepaths))
+	for i, group := range split {
+		if len(group) == 0 {
+			return nil, fmt.Errorf("%s: layer %d is empty", filename, i)
+		}
+		for _, p := range group {
+			if !want[p] {
+				return nil, fmt.Errorf("%s: layer %d lists %s, which is not in the closure graph", filename, i, p)
+			}
+			if seen[p] {
+				return nil, fmt.Errorf("%s: %s is listed twice", filename, p)
+			}
+			seen[p] = true
+		}
+	}
+	for _, sp := range storepaths {
+		if !seen[sp.Path] {
+			return nil, fmt.Errorf("%s: closure path %s is in no layer", filename, sp.Path)
+		}
+	}
+	return split, nil
+}

--- a/closure/splitfile_test.go
+++ b/closure/splitfile_test.go
@@ -1,0 +1,44 @@
+package closure
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSplit(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "split.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestSplitFromFileKeepsOrder(t *testing.T) {
+	g := []Storepath{{Path: "/nix/store/a"}, {Path: "/nix/store/b"}, {Path: "/nix/store/c"}}
+	split, err := SplitFromFile(g, writeSplit(t, `[["/nix/store/c"],["/nix/store/a","/nix/store/b"]]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(split) != 2 || split[0][0] != "/nix/store/c" || len(split[1]) != 2 {
+		t.Fatalf("unexpected split: %v", split)
+	}
+}
+
+func TestSplitFromFileRejectsIncompleteOrForeignSplits(t *testing.T) {
+	g := []Storepath{{Path: "/nix/store/a"}, {Path: "/nix/store/b"}}
+	for _, tc := range []struct{ body, want string }{
+		{`[["/nix/store/a"]]`, "in no layer"},
+		{`[["/nix/store/a","/nix/store/b","/nix/store/x"]]`, "not in the closure graph"},
+		{`[["/nix/store/a"],["/nix/store/a","/nix/store/b"]]`, "listed twice"},
+		{`[["/nix/store/a","/nix/store/b"],[]]`, "is empty"},
+		{`{"a": 1}`, "cannot unmarshal"},
+	} {
+		_, err := SplitFromFile(g, writeSplit(t, tc.body))
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("%s: want error containing %q, got %v", tc.body, tc.want, err)
+		}
+	}
+}

--- a/cmd/layers.go
+++ b/cmd/layers.go
@@ -27,6 +27,7 @@ var permsFilepath string
 var rewritesFilepath string
 var historyFilepath string
 var maxLayers int
+var layersJSONFilepath string
 
 // layerCmd represents the layer command
 var layersReproducibleCmd = &cobra.Command{
@@ -39,7 +40,13 @@ var layersReproducibleCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
 		}
-		storepaths, err := closure.SortedPathsByPopularity(closureGraph)
+		var split [][]string
+		var storepaths []string
+		if layersJSONFilepath != "" {
+			split, err = closure.SplitFromFile(closureGraph, layersJSONFilepath)
+		} else {
+			storepaths, err = closure.SortedPathsByPopularity(closureGraph)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -74,7 +81,12 @@ var layersReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayers(storepaths, maxLayers, parents, rewrites, ignore, perms, history)
+		var layers []types.Layer
+		if layersJSONFilepath != "" {
+			layers, err = nix.NewLayersFromSplit(split, parents, rewrites, ignore, perms, history)
+		} else {
+			layers, err = nix.NewLayers(storepaths, maxLayers, parents, rewrites, ignore, perms, history)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -98,7 +110,13 @@ var layersNonReproducibleCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
 		}
-		storepaths, err := closure.SortedPathsByPopularity(closureGraph)
+		var split [][]string
+		var storepaths []string
+		if layersJSONFilepath != "" {
+			split, err = closure.SplitFromFile(closureGraph, layersJSONFilepath)
+		} else {
+			storepaths, err = closure.SortedPathsByPopularity(closureGraph)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -133,7 +151,12 @@ var layersNonReproducibleCmd = &cobra.Command{
 			}
 		}
 
-		layers, err := nix.NewLayersNonReproducible(storepaths, maxLayers, tarDirectory, parents, rewrites, ignore, perms, history)
+		var layers []types.Layer
+		if layersJSONFilepath != "" {
+			layers, err = nix.NewLayersNonReproducibleFromSplit(split, tarDirectory, parents, rewrites, ignore, perms, history)
+		} else {
+			layers, err = nix.NewLayersNonReproducible(storepaths, maxLayers, tarDirectory, parents, rewrites, ignore, perms, history)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err)
 			os.Exit(1)
@@ -180,6 +203,7 @@ func init() {
 	layersNonReproducibleCmd.Flags().StringVarP(&permsFilepath, "perms", "", "", "A JSON file containing file permissions")
 	layersNonReproducibleCmd.Flags().StringVarP(&historyFilepath, "history", "", "", "A JSON file containing layer history")
 	layersNonReproducibleCmd.Flags().IntVarP(&maxLayers, "max-layers", "", 1, "The maximum number of layers")
+	layersNonReproducibleCmd.Flags().StringVarP(&layersJSONFilepath, "layers-json", "", "", "A JSON list of store path lists: the layer split to use, in order, instead of --max-layers")
 
 	rootCmd.AddCommand(layersReproducibleCmd)
 	layersReproducibleCmd.Flags().StringVarP(&ignore, "ignore", "", "", "Ignore the path from the list of storepaths")
@@ -187,5 +211,6 @@ func init() {
 	layersReproducibleCmd.Flags().StringVarP(&permsFilepath, "perms", "", "", "A JSON file containing file permissions")
 	layersReproducibleCmd.Flags().StringVarP(&historyFilepath, "history", "", "", "A JSON file containing layer history")
 	layersReproducibleCmd.Flags().IntVarP(&maxLayers, "max-layers", "", 1, "The maximum number of layers")
+	layersReproducibleCmd.Flags().StringVarP(&layersJSONFilepath, "layers-json", "", "", "A JSON list of store path lists: the layer split to use, in order, instead of --max-layers")
 
 }

--- a/default.nix
+++ b/default.nix
@@ -233,6 +233,9 @@ let
     # store path "popularity" as described in
     # https://grahamc.com/blog/nix-and-layered-docker-images
     maxLayers ? 1,
+    # A JSON file holding a list of store path lists: the layer split
+    # to use, in order. When set, maxLayers is ignored.
+    layersFile ? null,
     # Deprecated: will be removed on v1
     contents ? null,
     # Author, comment, created_by
@@ -263,6 +266,7 @@ let
 
     allDeps = deps ++ copyToRootList;
     tarDirectory = l.optionalString (!reproducible) "--tar-directory $out";
+    layersFlag = l.optionalString (layersFile != null) "--layers-json ${layersFile}";
 
     layersJSON = pkgs.runCommandLocal "layers.json" {} ''
       mkdir $out
@@ -271,6 +275,7 @@ let
         $out/layers.json \
         ${closureGraph allDeps ignore} \
         --max-layers ${toString maxLayers} \
+        ${layersFlag} \
         ${rewritesFlag} \
         ${permsFlag} \
         ${historyFlag} \

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -10,6 +10,7 @@
   uwsgi = pkgs.callPackage ./uwsgi { inherit nix2container; };
   openbar = pkgs.callPackage ./openbar.nix { inherit nix2container; };
   layered = pkgs.callPackage ./layered.nix { inherit nix2container; };
+  layersFile = pkgs.callPackage ./layers-file.nix { inherit nix2container; };
   nested = pkgs.callPackage ./nested.nix { inherit nix2container; };
   nix = pkgs.callPackage ./nix.nix { inherit nix2container; };
   nix-user = pkgs.callPackage ./nix-user.nix { inherit nix2container; };

--- a/examples/layers-file.nix
+++ b/examples/layers-file.nix
@@ -1,0 +1,25 @@
+{ pkgs, nix2container }:
+
+let
+  # A split computed at build time: hello in the first layer, all of
+  # its dependencies in the second one.
+  split = pkgs.runCommand "split.json" {
+    __structuredAttrs = true;
+    exportReferencesGraph.graph = [ pkgs.hello ];
+    nativeBuildInputs = [ pkgs.jq ];
+  } ''
+    jq --arg hello ${pkgs.hello} \
+      '[[$hello], [.graph[].path | select(. != $hello)]]' \
+      .attrs.json > $out
+  '';
+in
+nix2container.buildImage {
+  name = "layers-file";
+  config = {
+    entrypoint = ["${pkgs.hello}/bin/hello"];
+  };
+  layers = [(nix2container.buildLayer {
+    deps = [pkgs.hello];
+    layersFile = split;
+  })];
+}

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -64,14 +64,8 @@ func getPaths(storePaths []string, parents []types.Layer, rewrites []types.Rewri
 // If tarDirectory is not an empty string, the tar layer is written to
 // the disk. This is useful for layer containing non reproducible
 // store paths.
-func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1.History) (layers []types.Layer, err error) {
-	offset := 0
-	for offset < len(paths) {
-		max := offset + 1
-		if offset == maxLayers-1 {
-			max = len(paths)
-		}
-		layerPaths := paths[offset:max]
+func newLayers(groups []types.Paths, tarDirectory string, history v1.History) (layers []types.Layer, err error) {
+	for _, layerPaths := range groups {
 		layerPath := ""
 		var digest godigest.Digest
 		var size int64
@@ -99,20 +93,56 @@ func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1
 		}
 
 		layers = append(layers, layer)
-
-		offset = max
 	}
 	return layers, nil
 }
 
+// maxLayersGroups cuts paths into at most maxLayers groups: one path
+// per group, in order, and every remaining path in the last group.
+func maxLayersGroups(paths types.Paths, maxLayers int) (groups []types.Paths) {
+	offset := 0
+	for offset < len(paths) {
+		max := offset + 1
+		if offset == maxLayers-1 {
+			max = len(paths)
+		}
+		groups = append(groups, paths[offset:max])
+		offset = max
+	}
+	return groups
+}
+
+// splitGroups filters each group like getPaths does and drops the
+// groups left empty, for instance when all their paths are already in
+// a parent layer.
+func splitGroups(split [][]string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath) (groups []types.Paths) {
+	for _, storePaths := range split {
+		paths := getPaths(storePaths, parents, rewrites, exclude, perms)
+		if len(paths) > 0 {
+			groups = append(groups, paths)
+		}
+	}
+	return groups
+}
+
 func NewLayers(storePaths []string, maxLayers int, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
 	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
-	return newLayers(paths, "", maxLayers, history)
+	return newLayers(maxLayersGroups(paths, maxLayers), "", history)
 }
 
 func NewLayersNonReproducible(storePaths []string, maxLayers int, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) (layers []types.Layer, err error) {
 	paths := getPaths(storePaths, parents, rewrites, exclude, perms)
-	return newLayers(paths, tarDirectory, maxLayers, history)
+	return newLayers(maxLayersGroups(paths, maxLayers), tarDirectory, history)
+}
+
+// NewLayersFromSplit creates one layer per group of split, in order.
+// The split is not checked against a closure: see closure.SplitFromFile.
+func NewLayersFromSplit(split [][]string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
+	return newLayers(splitGroups(split, parents, rewrites, exclude, perms), "", history)
+}
+
+func NewLayersNonReproducibleFromSplit(split [][]string, tarDirectory string, parents []types.Layer, rewrites []types.RewritePath, exclude string, perms []types.PermPath, history v1.History) ([]types.Layer, error) {
+	return newLayers(splitGroups(split, parents, rewrites, exclude, perms), tarDirectory, history)
 }
 
 func isPathInLayers(layers []types.Layer, path types.Path) bool {

--- a/nix/layers.go
+++ b/nix/layers.go
@@ -78,7 +78,7 @@ func newLayers(paths types.Paths, tarDirectory string, maxLayers int, history v1
 		if tarDirectory == "" {
 			digest, size, err = TarPathsSum(layerPaths)
 		} else {
-			layerPath, digest, size, err = TarPathsWrite(paths, tarDirectory)
+			layerPath, digest, size, err = TarPathsWrite(layerPaths, tarDirectory)
 		}
 		if err != nil {
 			return layers, err

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -114,3 +114,26 @@ func TestNewLayersNonReproducibleWritesEachLayer(t *testing.T) {
 		assert.Equal(t, reproducible[i].Digest, written[i].Digest)
 	}
 }
+
+func TestNewLayersFromSplit(t *testing.T) {
+	split := [][]string{
+		{"../data/tar-directory/file1"},
+		{"../data/layer1/file1"},
+	}
+	layers, err := NewLayersFromSplit(split, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	assert.Len(t, layers, 2)
+	assert.Equal(t, "../data/tar-directory/file1", layers[0].Paths[0].Path)
+	assert.Equal(t, "../data/layer1/file1", layers[1].Paths[0].Path)
+
+	// A group whose paths are all in a parent layer yields no layer.
+	parents := layers[:1]
+	layers, err = NewLayersFromSplit(split, parents, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	assert.Len(t, layers, 1)
+	assert.Equal(t, "../data/layer1/file1", layers[0].Paths[0].Path)
+}

--- a/nix/layers_test.go
+++ b/nix/layers_test.go
@@ -92,3 +92,25 @@ func TestNewLayers(t *testing.T) {
 	}
 	assert.Equal(t, expected, layer)
 }
+
+// Each layer tar written to the tar directory must hold that layer's
+// paths only, so it must match the digest of the reproducible layer.
+func TestNewLayersNonReproducibleWritesEachLayer(t *testing.T) {
+	paths := []string{
+		"../data/layer1/file1",
+		"../data/tar-directory/file1",
+	}
+	reproducible, err := NewLayers(paths, 2, []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	written, err := NewLayersNonReproducible(paths, 2, t.TempDir(), []types.Layer{}, []types.RewritePath{}, "", []types.PermPath{}, v1.History{})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	assert.Len(t, written, 2)
+	for i := range written {
+		assert.Len(t, written[i].Paths, 1)
+		assert.Equal(t, reproducible[i].Digest, written[i].Digest)
+	}
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,6 +62,10 @@ let
       image = examples.layered;
       pattern = "Hello, world";
     };
+    layersFile = testScript {
+      image = examples.layersFile;
+      pattern = "Hello, world";
+    };
     nonReproducible = testScript {
       image = examples.nonReproducible;
       pattern = "A non reproducible image built the";


### PR DESCRIPTION
This adds `layersFile` to `buildLayer`: a JSON file with the layer split to use instead of `maxLayers`. It holds a list of store path lists, one list per layer, in order.

```nix
nix2container.buildLayer {
  deps = [ pkgs.hello ];
  layersFile = ./split.json; # [ [ "/nix/store/…-hello-2.12.2" ], [ "/nix/store/…-glibc-2.40-66", … ] ]
}
```

## Why

#204 proposed a new grouping algorithm for `maxLayers`. That is a lot of code to review, and any single algorithm will be wrong for some images. With `layersFile`, the split becomes an input, and users can bring the one they want. For instance, the `store_layers` list in the `conf.json` that nixpkgs' `streamLayeredImage` writes gives the same layers as `dockerTools` for the same closure, and `nix2container` then builds and pushes them.

I am closing #204 in favour of this PR.

## What changes

- `closure.SplitFromFile` reads the file and checks it against the closure graph. Every path of the graph must appear in exactly one list, no other path may appear, and no list may be empty. The command fails with the offending path otherwise.
- `layers-from-reproducible-storepaths` and `layers-from-non-reproducible-storepaths` take `--layers-json`. When it is set, `--max-layers` is ignored.
- `NewLayersFromSplit` and `NewLayersNonReproducibleFromSplit` are new. `NewLayers` and `NewLayersNonReproducible` keep their signatures and their behaviour. Only the internal `newLayers` now takes groups.
- `buildLayer` takes `layersFile ? null`. The README documents it.
- `examples/layers-file.nix` computes a split at build time (`hello` alone, then its dependencies), and `tests/default.nix` runs it.

## Depends on

This branch contains the commit of #219, because both touch `newLayers`. Please review the last commit only. Once #219 is merged, I will rebase this branch.

## Testing

- `nix build .#nix2container-bin` runs the Go tests, including the new ones for `SplitFromFile` and `NewLayersFromSplit`.
- `nix build .#examples.layersFile` gives an image with two layers in the order of the split.
- A `buildLayer` with a split that misses a path fails with `closure path /nix/store/…-xgcc-14.3.0-libgcc is in no layer`.
- `nix build .#skopeo-nix2container` builds.
- `golangci-lint run` reports no issues.
- I have not run the podman test of `tests/default.nix`.

---

Disclaimer: I used LLM assistance (Claude) while preparing this change and PR; I've reviewed the code and tested it myself.
